### PR TITLE
Improve pro completion and fix Linux/Docker setup

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,6 @@
+## TODO
+
+- [ ] Fix git tab completion — error `_git:.:48: no such file or directory: ""` means `$script` (path to `git-completion.bash`) is not found. The search paths in `files/zsh/completions/_git` (lines 35-43) don't include Homebrew's location on macOS. Fix: add the Homebrew bash-completion path (e.g. output of `brew --prefix`/share/bash-completion/completions/git) to the locations array, or set the zstyle in zshrc.
+- [x] Fix `scripts/10_setup_zsh.sh` line 13 failing in Docker (Linux)
+- [x] Update `build-container.sh` to use `docker buildx build`
+- [ ] Implement a helper script that displays configured keyboard shortcuts for different tools (tmux, fzf, vim). Should read from actual config files where possible and present them in a readable format.

--- a/build-container.sh
+++ b/build-container.sh
@@ -1,5 +1,5 @@
 #!/bin/bash -eux
 
 cd docker
-docker build . \
+docker buildx build . \
     --tag dotfiles:latest \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,6 @@ RUN command locale-gen en_US.UTF-8
 
 RUN apt-get install -y \
     curl \
-    fd \
     fd-find \
     fontconfig \
     git \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,6 +9,7 @@ RUN command locale-gen en_US.UTF-8
 
 RUN apt-get install -y \
     curl \
+    fd \
     fd-find \
     fontconfig \
     git \

--- a/files/shell/functions/pro
+++ b/files/shell/functions/pro
@@ -1,3 +1,3 @@
 function pro() {
-  cd $PROJECTS_HOME/$1
+  cd "$PROJECTS_HOME/$1"
 }

--- a/files/zsh/completions/_pro
+++ b/files/zsh/completions/_pro
@@ -1,7 +1,7 @@
 #compdef pro _pro
 
 function _pro() {
-  compadd `ls -laH $PROJECTS_HOME | grep -e '^d' | awk '{print $9}' | grep -v '^\.'`
+  _files -W "$PROJECTS_HOME" -/
   return 0
 }
 

--- a/scripts/10_setup_zsh.sh
+++ b/scripts/10_setup_zsh.sh
@@ -10,7 +10,11 @@ echo "$script_dir"
 . "$script_dir/_config.sh"
 
 echo 'Configuring zsh...'
-confirm_binaries "git" "zsh" "fd"
+if [ "$DOT_OS" = "linux" ]; then
+    confirm_binaries "git" "zsh" "fdfind"
+else
+    confirm_binaries "git" "zsh" "fd"
+fi
 
 mkdir -p "$HOME/.zsh/functions" "$HOME/.zsh/completions"
 cp -f "$DOT_ROOT/files/zsh/zprofile" "$HOME/.zprofile"

--- a/scripts/10_setup_zsh.sh
+++ b/scripts/10_setup_zsh.sh
@@ -10,7 +10,7 @@ echo "$script_dir"
 . "$script_dir/_config.sh"
 
 echo 'Configuring zsh...'
-confirm_binaries "git" "zsh" 
+confirm_binaries "git" "zsh" "fd"
 
 mkdir -p "$HOME/.zsh/functions" "$HOME/.zsh/completions"
 cp -f "$DOT_ROOT/files/zsh/zprofile" "$HOME/.zprofile"


### PR DESCRIPTION
## Summary

- Replace `pro` tab completion with `_files -W "$PROJECTS_HOME" -/` for slash-separated subfolder navigation (e.g. `pro dotfiles/scr<Tab>`)
- Fix `10_setup_zsh.sh` to check for `fdfind` on Linux and `fd` on Darwin
- Remove invalid `fd` apt package from Dockerfile (binary is `fdfind`, symlinked to `fd`)
- Switch `build-container.sh` to `docker buildx build`
- Add `CLAUDE.md` with project TODOs

## Test plan

- [ ] `pro <Tab>` completes top-level dirs in `$PROJECTS_HOME`
- [ ] `pro dotfiles/<Tab>` completes subdirectories
- [ ] `./build-container.sh` builds without legacy builder warning
- [ ] `scripts/10_setup_zsh.sh` runs successfully inside the Docker container

🤖 Generated with [Claude Code](https://claude.com/claude-code)