### PR TITLE
Fix tmux status bar and Docker improvements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,9 @@
 ## TODO
 
-- [ ] Fix git tab completion — error `_git:.:48: no such file or directory: ""` means `$script` (path to `git-completion.bash`) is not found. The search paths in `files/zsh/completions/_git` (lines 35-43) don't include Homebrew's location on macOS. Fix: add the Homebrew bash-completion path (e.g. output of `brew --prefix`/share/bash-completion/completions/git) to the locations array, or set the zstyle in zshrc.
 - [x] Fix `scripts/10_setup_zsh.sh` line 13 failing in Docker (Linux)
 - [x] Update `build-container.sh` to use `docker buildx build`
 - [x] Update README.md to reflect current tools and setup process.
+- [ ] Fix git tab completion — error `_git:.:48: no such file or directory: ""` means `$script` (path to `git-completion.bash`) is not found. The search paths in `files/zsh/completions/_git` (lines 35-43) don't include Homebrew's location on macOS. Fix: add the Homebrew bash-completion path (e.g. output of `brew --prefix`/share/bash-completion/completions/git) to the locations array, or set the zstyle in zshrc.
+- [ ] Configure AWS pager — add `export AWS_PAGER=""` to shell env so AWS CLI output is not paged.
 - [ ] Implement a helper script that displays configured keyboard shortcuts for different tools (tmux, fzf, vim). Should read from actual config files where possible and present them in a readable format.
+- [x] Fix tmux status bar — on startup it shows stale environment (e.g. wifi name and weather) instead of reloading config. Should display user and hostname instead.

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -34,5 +34,7 @@ RUN wget -P /home/jan/.local/share/fonts https://github.com/ryanoasis/nerd-fonts
 RUN mkdir -p ~/.local/bin \
     && ln -s $(which fdfind) ~/.local/bin/fd
 
+RUN touch /home/jan/.zshrc
+
 CMD [ "/bin/zsh" ]
 WORKDIR /home/jan

--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -69,8 +69,10 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 
-run '~/.tmux/plugins/tpm/tpm'
-
 # https://draculatheme.com/tmux
+# Plugin config must come before tpm's run command
 set -g @dracula-plugins "ssh-session"
 set -g @dracula-show-powerline true
+set -g @dracula-show-left-icon session
+
+run '~/.tmux/plugins/tpm/tpm'

--- a/run-container.sh
+++ b/run-container.sh
@@ -7,4 +7,5 @@ docker run \
     --volume $(pwd):/home/jan/dotfiles \
     --hostname dotfiles-test \
     --env DOT_DEBUG="true" \
+    --workdir /home/jan/dotfiles \
     dotfiles:latest


### PR DESCRIPTION
## Summary
- Fix tmux status bar showing stale plugins (wifi/weather) by moving dracula config before tpm's `run` command
- Set Docker workdir to `/home/jan/dotfiles` so container starts in the mounted volume
- Add empty `.zshrc` in Dockerfile to suppress zsh new-user startup routine

## Test plan
- [ ] Start tmux and verify status bar shows user/hostname instead of wifi/weather
- [ ] Run `run-container.sh` and verify shell starts in `/home/jan/dotfiles`
- [ ] Verify no zsh startup prompt appears when launching the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)