### PR TITLE
Configure AWS pager

### DIFF
--- a/files/zsh/zshenv
+++ b/files/zsh/zshenv
@@ -1,8 +1,8 @@
 # .zshenv is always sourced. It often contains exported variables that should be available to other programs.
 [ -v DOT_DEBUG ] && echo '-> .zshenv'
 
-export TERM="xterm-256color"
 export LANG=en_US.UTF-8
+export TERM="xterm-256color"
 
 # set PATH so it includes user's private bin if it exists
 if [ -d "$HOME/.local/bin" ] ; then

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -40,6 +40,11 @@ setopt HIST_REDUCE_BLANKS        # Remove superfluous blanks before recording en
 setopt HIST_VERIFY               # Don't execute immediately upon history expansion.
 setopt HIST_BEEP
 
+# aws
+if command -v aws &> /dev/null; then
+  export AWS_PAGER=""
+fi
+
 # fzf
 if [ -f ~/.fzf.zsh ]; then
     source ~/.fzf.zsh
@@ -48,7 +53,6 @@ if [ -f ~/.fzf.zsh ]; then
 fi
 
 # golang
-
 if command -v go &> /dev/null; then
   export GOROOT="$(brew --prefix golang)/libexec"
   export GOPATH="$HOME/go"


### PR DESCRIPTION
## Summary
- Add `export AWS_PAGER=""` to `zshrc` guarded by an `aws` binary check
- Sort exported variables in `zshenv` alphabetically

## Test plan
- [ ] Open a new shell and verify `AWS_PAGER` is set when `aws` is installed
- [ ] Verify `aws` commands no longer open a pager

🤖 Generated with [Claude Code](https://claude.com/claude-code)