### PR TITLE
Add lint script, Makefile, and new TODOs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,3 +46,8 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Fix git tab completion — error `_git:.:48: no such file or directory: ""` means `$script` (path to `git-completion.bash`) is not found. The search paths in `files/zsh/completions/_git` (lines 35-43) don't include Homebrew's location on macOS. Fix: add the Homebrew bash-completion path (e.g. output of `brew --prefix`/share/bash-completion/completions/git) to the locations array, or set the zstyle in zshrc.
 - [ ] Implement a helper script that displays configured keyboard shortcuts for different tools (tmux, fzf, vim). Should read from actual config files where possible and present them in a readable format.
 - [ ] Add automated tests — two-tier approach: fast lint checks (`tests/lint.sh`) and Docker-based integration tests (`tests/integration.sh`). See plan in `~/.claude/plans/adaptive-dreaming-narwhal.md` and memory `project_testing_strategy.md`.
+- [ ] Output the dotfiles build/commit ID when starting a new interactive shell — useful for verifying which version is installed.
+- [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).
+- [ ] Enable/fix AWS CLI tab completion (`complete -C aws_completer aws` is configured in `zshrc` but may not work if `aws_completer` is not on PATH).
+- [ ] Enable/fix Terraform tab completion (`complete -o nospace -C /opt/homebrew/bin/terraform terraform` is hardcoded in `zshrc` — path may differ across machines).
+- [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+.PHONY: help lint docker-build docker-run
+
+help:
+	@echo "lint          check syntax of all config and shell files"
+	@echo "docker-build  build the dotfiles Docker image"
+	@echo "docker-run    build image and launch interactive container"
+
+lint:
+	./tests/lint.sh
+
+docker-build:
+	./build-container.sh
+
+docker-run: docker-build
+	./run-container.sh

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+PASS=0
+FAIL=0
+
+check() {
+    local label="$1"; shift
+    if "$@" &>/dev/null; then
+        echo "PASS: $label"
+        PASS=$((PASS + 1))
+    else
+        echo "FAIL: $label"
+        FAIL=$((FAIL + 1))
+    fi
+}
+
+# Shell scripts — bash syntax check
+for f in "$ROOT"/scripts/*.sh; do
+    check "bash -n scripts/$(basename "$f")" bash -n "$f"
+done
+
+# Zsh config files
+for f in "$ROOT"/files/zsh/zshenv "$ROOT"/files/zsh/zshrc "$ROOT"/files/zsh/zprofile; do
+    check "zsh -n files/zsh/$(basename "$f")" zsh -n "$f"
+done
+
+# Zsh completions
+for f in "$ROOT"/files/zsh/completions/*; do
+    check "zsh -n files/zsh/completions/$(basename "$f")" zsh -n "$f"
+done
+
+# Shell functions and aliases
+for f in "$ROOT"/files/shell/functions/*; do
+    check "zsh -n files/shell/functions/$(basename "$f")" zsh -n "$f"
+done
+check "zsh -n files/shell/aliases" zsh -n "$ROOT/files/shell/aliases"
+
+# JSON
+check "json: files/vscode/settings.json" python3 -m json.tool "$ROOT/files/vscode/settings.json"
+
+# TOML
+check "toml: files/starship/starship.toml" python3 -c "
+import tomllib, sys
+with open(sys.argv[1], 'rb') as f:
+    tomllib.load(f)
+" "$ROOT/files/starship/starship.toml"
+
+# Git config
+check "git config: files/git/gitconfig" git config --file "$ROOT/files/git/gitconfig" --list
+
+# Tmux config (skipped if tmux not available)
+if command -v tmux &>/dev/null; then
+    check "tmux: files/tmux/tmux.conf" tmux -f "$ROOT/files/tmux/tmux.conf" new-session -d -s "lint_$$"
+    tmux kill-session -t "lint_$$" 2>/dev/null || true
+fi
+
+echo ""
+echo "Results: $PASS passed, $FAIL failed"
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary
- `tests/lint.sh`: syntax checks for shell scripts, zsh configs, completions, functions, JSON, TOML, git config, and tmux (20 checks, all passing)
- `Makefile`: `lint`, `docker-build`, `docker-run` targets with default `help` output
- `CLAUDE.md`: five new TODO items (commit ID in shell, generic dev container, AWS/Terraform/kubectl completions)

## Test plan
- [ ] `make` shows help output
- [ ] `make lint` passes all 20 checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)