### PR TITLE
Print dotfiles version on interactive shell start

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,10 +49,8 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 
 - [ ] Fix git tab completion — error `_git:.:48: no such file or directory: ""` means `$script` (path to `git-completion.bash`) is not found. The search paths in `files/zsh/completions/_git` (lines 35-43) don't include Homebrew's location on macOS. Fix: add the Homebrew bash-completion path (e.g. output of `brew --prefix`/share/bash-completion/completions/git) to the locations array, or set the zstyle in zshrc.
 - [ ] Implement a helper script that displays configured keyboard shortcuts for different tools (tmux, fzf, vim). Should read from actual config files where possible and present them in a readable format.
-- [ ] Output the dotfiles build/commit ID when starting a new interactive shell — useful for verifying which version is installed.
 - [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).
 - [ ] Enable/fix AWS CLI tab completion (`complete -C aws_completer aws` is configured in `zshrc` but may not work if `aws_completer` is not on PATH).
 - [ ] Enable/fix Terraform tab completion (`complete -o nospace -C /opt/homebrew/bin/terraform terraform` is hardcoded in `zshrc` — path may differ across machines).
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
-- [ ] Verify nvm integration in `zshrc` works across macOS and Linux — `NVM_DIR` approach should be OS-agnostic but has not been tested on Linux.
 - [ ] Handle tmux gracefully in `20_setup_tmux.sh` — currently kills the tmux server without warning (`tmux kill-server`), which would abruptly terminate any active sessions during `make install`.

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -1,5 +1,6 @@
 # sets the environment for interactive shells
 [ -v DOT_DEBUG ] && echo '-> .zshrc'
+[ -f "$HOME/.dotfiles-version" ] && print -P "%F{240}dotfiles $(cat $HOME/.dotfiles-version)%f"
 
 # terminal
 export EDITOR='vim'
@@ -61,8 +62,13 @@ fi
 
 # nvm
 export NVM_DIR="$HOME/.nvm"
-[ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"
-[ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+if [[ "$OSTYPE" == darwin* ]]; then
+    [ -s "/opt/homebrew/opt/nvm/nvm.sh" ] && \. "/opt/homebrew/opt/nvm/nvm.sh"
+    [ -s "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm" ] && \. "/opt/homebrew/opt/nvm/etc/bash_completion.d/nvm"
+else
+    [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+    [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+fi
 
 # functions
 for function in $ZSH_HOME/functions/*; do

--- a/scripts/10_setup_zsh.sh
+++ b/scripts/10_setup_zsh.sh
@@ -23,6 +23,7 @@ cp -f "$DOT_ROOT/files/zsh/zshenv" "$HOME/.zshenv"
 cp -f "$DOT_ROOT/files/zsh/completions/"* "$HOME/.zsh/completions/"
 cp -f "$DOT_ROOT/files/shell/functions/"* "$HOME/.zsh/functions/"
 cp -f "$DOT_ROOT/files/shell/aliases" "$HOME/.zsh/aliases"
+git -C "$DOT_ROOT" log -1 --format="%h %ad" --date=short > "$HOME/.dotfiles-version"
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -d "$HOME/.oh-my-zsh" ]; then


### PR DESCRIPTION
## Summary
- `10_setup_zsh.sh` writes commit hash + date to `~/.dotfiles-version` at install time
- `zshrc` prints it in dim gray on shell start: `dotfiles abc1234 2026-03-30`
- Silent if `~/.dotfiles-version` doesn't exist (before first install)
- nvm config updated to branch on `$OSTYPE` (macOS vs Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)