### PR TITLE
Handle tmux gracefully during make install

### DIFF
--- a/scripts/20_setup_tmux.sh
+++ b/scripts/20_setup_tmux.sh
@@ -6,9 +6,13 @@
 echo 'Configuring tmux...'
 confirm_binaries "git" "tmux"
 
-tmux kill-server || true # kill tmux server if running
-
 cp -f "${DOT_ROOT}/files/tmux/tmux.conf" $HOME/.tmux.conf
+
+if tmux list-sessions &>/dev/null; then
+    echo "tmux server is running — reload config with prefix+r or 'tmux source-file ~/.tmux.conf'" >> "$HOME/.dotfiles-notes"
+else
+    tmux kill-server || true
+fi
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -d "$HOME/.tmux/plugins/tpm" ]; then

--- a/scripts/run_all.sh
+++ b/scripts/run_all.sh
@@ -4,6 +4,8 @@ set -o pipefail
 . "$(dirname "$0")/_config.sh"
 { set +x; } 2>/dev/null  # trace is for child scripts, not this one
 
+rm -f "$HOME/.dotfiles-notes"
+
 PASS=()
 FAIL=()
 
@@ -42,5 +44,12 @@ for s in "${PASS[@]+"${PASS[@]}"}"; do echo "  ✔ $s"; done
 for s in "${FAIL[@]+"${FAIL[@]}"}"; do echo "  ✖ $s"; done
 echo ""
 echo "${#PASS[@]} passed, ${#FAIL[@]} failed"
+
+if [ -f "$HOME/.dotfiles-notes" ]; then
+    echo ""
+    echo "Notes:"
+    while IFS= read -r line; do echo "  ! $line"; done < "$HOME/.dotfiles-notes"
+    rm "$HOME/.dotfiles-notes"
+fi
 
 [ "${#FAIL[@]}" -eq 0 ]


### PR DESCRIPTION
## Summary
- `20_setup_tmux.sh`: no longer kills the tmux server if sessions are active — instead writes a reload reminder to `~/.dotfiles-notes`
- `run_all.sh`: clears `~/.dotfiles-notes` at the start of each run, then displays and removes any notes after the summary

The notes mechanism is generic — any setup script can append to `~/.dotfiles-notes` to surface a message to the user after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)