### PR TITLE
Add git workflow conventions and /todo command

### DIFF
--- a/.claude/commands/todo.md
+++ b/.claude/commands/todo.md
@@ -1,0 +1,8 @@
+Add a new TODO item to CLAUDE.md.
+
+The user wants to add this TODO: $ARGUMENTS
+
+1. Read CLAUDE.md
+2. Add `- [ ] $ARGUMENTS` as a new item in the `## TODO` section
+3. Keep it concise and consistent with existing TODO items
+4. Confirm the item was added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Always create a new branch before making any changes — never commit directly to main.
 - Always run `make lint` before committing.
+- Always check if `README.md` requires updating before committing.
 - Never push to remote without explicit user confirmation.
 
 ## What this repo is

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,6 +6,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 - Keep `README.md` up to date whenever making changes that affect setup, usage, or tooling.
 
+## Git workflow
+
+- Always create a new branch before making any changes — never commit directly to main.
+- Always run `make lint` before committing.
+- Never push to remote without explicit user confirmation.
+
 ## What this repo is
 
 Dotfiles for macOS and Linux. Config files live in `files/`, setup scripts in `scripts/`. Scripts symlink or copy files into `$HOME`.


### PR DESCRIPTION
## Summary
- Adds `## Git workflow` section to `CLAUDE.md` with branching, lint, README, and push rules
- Adds `.claude/commands/todo.md` custom `/todo` slash command

## Test plan
- [ ] Verify `/todo` command adds items to `CLAUDE.md` TODO section

🤖 Generated with [Claude Code](https://claude.com/claude-code)