### PR TITLE
Add tmux plugin auto-install and update help pages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,6 +61,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [x] Add `make update` target — pull latest from GitHub and reinstall.
 - [x] Implement a helper script that displays configured keyboard shortcuts for different tools (tmux, fzf, vim). Should read from actual config files where possible and present them in a readable format.
 - [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only).
+- [ ] Install tmux-resurrect and tmux-continuum via setup script (currently only installed via TPM manually).
 - [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).
 - [ ] Enable/fix AWS CLI tab completion (`complete -C aws_completer aws` is configured in `zshrc` but may not work if `aws_completer` is not on PATH).
 - [ ] Enable/fix Terraform tab completion (`complete -o nospace -C /opt/homebrew/bin/terraform terraform` is hardcoded in `zshrc` — path may differ across machines).

--- a/files/help/fzf
+++ b/files/help/fzf
@@ -2,11 +2,11 @@
 
 ## Key bindings
 
-| Key       | Action                                                        |
-|-----------|---------------------------------------------------------------|
-| `Ctrl+T`  | Insert a project directory path (searches `$PROJECTS_HOME`)   |
-| `Ctrl+R`  | Search shell history and insert selected command              |
-| `Alt+C`   | cd into a fuzzy-matched directory                             |
+| Key          | Action                                                        |
+|--------------|---------------------------------------------------------------|
+| `Ctrl+T`     | Insert a project directory path (searches `$PROJECTS_HOME`)   |
+| `Ctrl+R`     | Search shell history and insert selected command              |
+| `cd **<tab>` | cd into a fuzzy-matched directory                             |
 
 ## Navigation inside fzf
 

--- a/files/help/tmux
+++ b/files/help/tmux
@@ -2,19 +2,41 @@
 
 > Prefix is `Ctrl+O` (not the default `Ctrl+B`)
 
+## Sessions
+
+| Key                   | Action                          |
+|-----------------------|---------------------------------|
+| `tmux new -s name`    | Create a named session          |
+| `tmux attach`         | Attach to last session          |
+| `tmux attach -t name` | Attach to a named session       |
+| `prefix + d`          | Detach from tmux                |
+| `prefix + $`          | Rename session                  |
+| `prefix + s`          | List sessions (interactive)     |
+| `prefix + (`          | Switch to previous session      |
+| `prefix + )`          | Switch to next session          |
+| `prefix + Ctrl+S`     | Save environment (resurrect)    |
+| `prefix + Ctrl+R`     | Restore environment (resurrect) |
+
+Within the session list (`prefix + s`): `x` to delete, `t` to tag.
+
+Attach to a remote tmux over SSH:
+```sh
+ssh darth.local -t "/opt/homebrew/bin/tmux attach"
+```
+
 ## Panes
 
-| Key                    | Action                                  |
-|------------------------|-----------------------------------------|
-| `prefix + \|`          | Split horizontally (keeps current path) |
-| `prefix + -`           | Split vertically (keeps current path)   |
-| `prefix + h/j/k/l`     | Move between panes (vi-style)           |
-| `prefix + H/J/K/L`     | Resize pane (repeatable)                |
-| `prefix + z`           | Zoom pane to full screen / unzoom       |
-| `prefix + !`           | Break pane out into its own window      |
-| `prefix + {`           | Swap pane with the one above/left       |
-| `prefix + }`           | Swap pane with the one below/right      |
-| `prefix + q`           | Show pane numbers (type number to jump) |
+| Key                | Action                                  |
+|--------------------|-----------------------------------------|
+| `prefix + \|`      | Split horizontally (keeps current path) |
+| `prefix + -`       | Split vertically (keeps current path)   |
+| `prefix + h/j/k/l` | Move between panes (vi-style)           |
+| `prefix + H/J/K/L` | Resize pane (repeatable)                |
+| `prefix + z`       | Zoom pane to full screen / unzoom       |
+| `prefix + !`       | Break pane out into its own window      |
+| `prefix + {`       | Swap pane with the one above/left       |
+| `prefix + }`       | Swap pane with the one below/right      |
+| `prefix + q`       | Show pane numbers (type number to jump) |
 
 ## Layouts
 
@@ -35,13 +57,13 @@ prefix + :swap-pane -s 1 -t 3
 
 ## Windows
 
-| Key            | Action                                       |
-|----------------|----------------------------------------------|
-| `prefix + c`   | New window                                   |
-| `prefix + ,`   | Rename current window                        |
-| `prefix + w`   | Visual window list                           |
-| `prefix + 1–9` | Jump to window by number (starts at 1)       |
-| `prefix + n/p` | Next / previous window                       |
+| Key            | Action                                 |
+|----------------|----------------------------------------|
+| `prefix + c`   | New window                             |
+| `prefix + ,`   | Rename current window                  |
+| `prefix + w`   | Visual window list                     |
+| `prefix + 1–9` | Jump to window by number (starts at 1) |
+| `prefix + n/p` | Next / previous window                 |
 
 ## Other
 
@@ -54,16 +76,9 @@ prefix + :swap-pane -s 1 -t 3
 
 | Key              | Action                  |
 |------------------|-------------------------|
-| `prefix + I`     | Install new plugins      |
-| `prefix + U`     | Update plugins           |
-| `prefix + Alt+U` | Remove unlisted plugins  |
+| `prefix + I`     | Install new plugins     |
+| `prefix + U`     | Update plugins          |
+| `prefix + Alt+U` | Remove unlisted plugins |
 
-**tmux-resurrect / tmux-continuum**
-
-| Key               | Action                                    |
-|-------------------|-------------------------------------------|
-| `prefix + Ctrl+S` | Save session (windows + panes + paths)    |
-| `prefix + Ctrl+R` | Restore last saved session                |
-
-Continuum auto-saves every 15 min. Resurrect restores pane layout but not
+Continuum auto-saves every 10 min. Resurrect restores pane layout but not
 running processes unless configured with `@resurrect-capture-pane-contents`.

--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -55,10 +55,16 @@ set -g status-position top
 set -g mouse on
 bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
 
+# Resurrect settings
+set -g @resurrect-processes 'ssh'
+set -g @resurrect-capture-pane-contents 'on'
+
+# Enable tmux-continuum restore
+set -g @continuum-restore 'on'
+set -g @continuum-save-interval '10'
+
 # https://gist.github.com/ssh352/785395faad3163b2e0de32649f7ed45c
 set-option default-terminal "screen-256color"
-
-
 
 #### ----> PLUGINS
 

--- a/scripts/20_setup_tmux.sh
+++ b/scripts/20_setup_tmux.sh
@@ -21,4 +21,6 @@ if [ -n "$DOT_FORCE" ] || [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
     git clone --depth 1 https://github.com/tmux-plugins/tpm $HOME/.tmux/plugins/tpm
 fi
 
-echo "-> tmux setup finished, use 'prefix+I' (capital 'i') to install tmux plugins."
+"$HOME/.tmux/plugins/tpm/bin/install_plugins"
+
+echo "-> tmux setup finished."


### PR DESCRIPTION
## Summary

- `20_setup_tmux.sh`: run `tpm/bin/install_plugins` headlessly after cloning TPM — resurrect and continuum now install automatically without needing `prefix+I`
- tmux help page: expanded sessions section (named sessions, session switching), fixed table alignment, added SSH attach example
- fzf help page: minor binding correction

## Test plan

- [ ] `make lint` passes
- [ ] `make install` — tmux-resurrect and tmux-continuum installed automatically
- [ ] `dfh tmux` renders correctly with bat
- [ ] `make docker-build && make docker-run` → `make install` → plugins installed headlessly

🤖 Generated with [Claude Code](https://claude.com/claude-code)