### PR TITLE
fix: use command -v in confirm_binaries instead of broken which pattern

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,6 +71,6 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Fix `zprofile` brew shellenv — `eval "$(/opt/homebrew/bin/brew shellenv)"` has no existence check; will error if Homebrew isn't at that path.
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux.
 - [ ] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`.
-- [ ] Fix `confirm_binaries` in `_config.sh` — `if $(which "${x}" >/dev/null)` is broken; should use `command -v`.
+- [x] Fix `confirm_binaries` in `_config.sh` — `if $(which "${x}" >/dev/null)` is broken; should use `command -v`.
 - [ ] Fix stale `CLAUDE.md` reference to `99_setup_everything.sh` (replaced by `make install` / `scripts/run_all.sh`).
 - [ ] Fix `40_setup_git.sh` implicit dependency — assumes `~/.zsh/completions/` exists (created by `10_setup_zsh.sh`); should create it explicitly.

--- a/scripts/_config.sh
+++ b/scripts/_config.sh
@@ -4,7 +4,7 @@
 
 confirm_binaries() {
     for x in "$@"; do
-        if $(which "${x}" 1>&1 >/dev/null); then
+        if command -v "${x}" >/dev/null 2>&1; then
             echo "✔ ...confirming: $x"
         else
             echo "⛌ ...missing: $x"


### PR DESCRIPTION
Replaces `if $(which "${x}" 1>&1 >/dev/null)` with `command -v "${x}" >/dev/null 2>&1`, which correctly tests for binary existence using a POSIX shell builtin.

Closes #18