### PR TITLE
fix: move Homebrew PATH setup to zshenv for SSH compatibility

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,6 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 
 ## TODO
 
-- [ ] Investigate `$PATH` over SSH — tools like `tmux` may not be on PATH when connecting remotely.
 - [ ] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`.
 - [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only).
 - [ ] Enable/fix AWS CLI tab completion (`complete -C aws_completer aws` is configured in `zshrc` but may not work if `aws_completer` is not on PATH).
@@ -66,6 +65,5 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
 - [ ] Fix `zshrc` Go block — `GOROOT` uses `brew --prefix golang` which fails on Linux; should be guarded by OS check.
 - [ ] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed.
-- [ ] Fix `zprofile` brew shellenv — `eval "$(/opt/homebrew/bin/brew shellenv)"` has no existence check; will error if Homebrew isn't at that path.
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux.
 - [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).

--- a/files/zsh/zprofile
+++ b/files/zsh/zprofile
@@ -14,6 +14,3 @@ case "$(uname)" in
         export PLATFORM='unknown'
         ;;
 esac
-
-# Homebrew shellenv is initialised in .zshenv so it is available in non-login shells too.
-# Nothing to do here.

--- a/files/zsh/zprofile
+++ b/files/zsh/zprofile
@@ -15,6 +15,5 @@ case "$(uname)" in
         ;;
 esac
 
-if [ "$PLATFORM" = "darwin" ]; then
-    eval "$(/opt/homebrew/bin/brew shellenv)"
-fi
+# Homebrew shellenv is initialised in .zshenv so it is available in non-login shells too.
+# Nothing to do here.

--- a/files/zsh/zshenv
+++ b/files/zsh/zshenv
@@ -4,6 +4,12 @@
 export LANG=en_US.UTF-8
 export TERM="xterm-256color"
 
+# Homebrew - must live here (not just .zprofile) so PATH is set for ALL shell types,
+# including non-login shells invoked over SSH (e.g. `ssh host tmux`).
+if [ -x "/opt/homebrew/bin/brew" ]; then
+    eval "$(/opt/homebrew/bin/brew shellenv)"
+fi
+
 # set PATH so it includes user's private bin if it exists
 if [ -d "$HOME/.local/bin" ] ; then
     PATH="$HOME/.local/bin:$PATH"

--- a/files/zsh/zshenv
+++ b/files/zsh/zshenv
@@ -4,8 +4,7 @@
 export LANG=en_US.UTF-8
 export TERM="xterm-256color"
 
-# Homebrew - must live here (not just .zprofile) so PATH is set for ALL shell types,
-# including non-login shells invoked over SSH (e.g. `ssh host tmux`).
+# Homebrew - must live here so PATH is set for ALL shell types including non-login shells invoked over SSH
 if [ -x "/opt/homebrew/bin/brew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
 fi


### PR DESCRIPTION
.zprofile is only sourced for login shells. When SSH runs a command directly (e.g. `ssh host tmux`), only .zshenv is sourced, so /opt/homebrew/bin was missing from PATH and Homebrew-installed tools could not be found.

Moves `brew shellenv` to .zshenv (always sourced) with a proper existence check. Removes the redundant/unsafe call from .zprofile.

Fixes #21

Generated with [Claude Code](https://claude.ai/code)