### PR TITLE
feat: add git analytics aliases and tmux-ssh TODO

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 
 ## TODO
 
+- [ ] Add `tmux-ssh` function — SSH into a home network machine and attach to tmux (or create a new session if none running). Usage: `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`.
 - [ ] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`.
 - [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only).
 - [ ] Enable/fix AWS CLI tab completion (`complete -C aws_completer aws` is configured in `zshrc` but may not work if `aws_completer` is not on PATH).

--- a/files/git/gitconfig
+++ b/files/git/gitconfig
@@ -14,6 +14,17 @@
   cam = commit --amend --no-edit
   pfff = push --force
 
+  # Shows the top 20 most changed files in the last year
+  hotfiles = "!f() { git log --format=format: --name-only --since=\"${1:-1 year ago}\" | sort | uniq -c | sort -nr | head -20; }; f"
+  # Shows a list of contributors ranked by number of commits
+  rank = shortlog -sn --no-merges
+  # Shows commit frequency grouped by Year-Month
+  momentum = "!git log --format='%ad' --date=format:'%Y-%m' | sort | uniq -c"
+  # Identifies the top 20 files most associated with 'fix', 'bug', or 'broken'
+  bugfiles = "!git log -i -E --grep='fix|bug|broken' --name-only --format='' | sort | uniq -c | sort -nr | head -20"
+  # Lists commit subjects containing emergency-related keywords
+  incidents = "!f() { git log --oneline --since=\"${1:-1 year ago}\" | grep -iE 'revert|hotfix|emergency|rollback'; }; f"
+
   alias = "config --get-regexp ^alias\\."
 [color]
 	ui = true


### PR DESCRIPTION
## Summary

- Add 5 git aliases to `gitconfig` for repo analytics: `hotfiles`, `rank`, `momentum`, `bugfiles`, `incidents`
- Add `tmux-ssh` TODO item to `CLAUDE.md`

## Test plan

- [x] `make lint` passes (22/22)

🤖 Generated with [Claude Code](https://claude.com/claude-code)