### PR TITLE
fix: cross-platform clipboard in tmux copy-mode

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -53,7 +53,13 @@ set -g status-position top
 
 # mouse support and clipboard -> https://stackoverflow.com/a/53545001/512155
 set -g mouse on
-bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+if-shell "uname | grep -q Darwin" {
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "pbcopy"
+    bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "pbcopy"
+} {
+    bind-key -T copy-mode-vi MouseDragEnd1Pane send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+    bind-key -T copy-mode-vi y send-keys -X copy-pipe-and-cancel "xclip -selection clipboard"
+}
 
 # Resurrect settings
 set -g @resurrect-processes 'ssh'


### PR DESCRIPTION
## Summary

- Replace hardcoded `pbcopy` with an `if-shell` OS check
- macOS: pipes to `pbcopy`
- Linux: pipes to `xclip -selection clipboard`
- Applies to both mouse drag (`MouseDragEnd1Pane`) and keyboard copy (`y`) in `copy-mode-vi`

## Test plan

- [ ] On macOS: copy text in tmux via mouse drag and `y` — verify it lands in system clipboard
- [ ] On Linux (Docker): copy text in tmux — verify `xclip -selection clipboard` receives it

🤖 Generated with [Claude Code](https://claude.com/claude-code)