### PR TITLE
feat: add shfmt and shellcheck to lint pipeline

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,6 +12,8 @@ RUN apt-get update && apt-get install -y \
     locales \
     make \
     python3 \
+    shellcheck \
+    shfmt \
     tmux \
     tree \
     unzip \

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -4,7 +4,7 @@ docker run \
     --rm \
     --interactive \
     --tty \
-    --volume $(pwd):/home/jan/dotfiles \
+    --volume "$(pwd):/home/jan/dotfiles" \
     --hostname dotfiles-test \
     --env DOT_VERBOSE="true" \
     --workdir /home/jan/dotfiles \

--- a/scripts/20_setup_tmux.sh
+++ b/scripts/20_setup_tmux.sh
@@ -6,10 +6,10 @@
 echo 'Configuring tmux...'
 confirm_binaries "git" "tmux"
 
-cp -f "${DOT_ROOT}/files/tmux/tmux.conf" $HOME/.tmux.conf
+cp -f "${DOT_ROOT}/files/tmux/tmux.conf" "$HOME/.tmux.conf"
 
-if tmux list-sessions &>/dev/null; then
-    echo "tmux server is running — reload config with prefix+r or 'tmux source-file ~/.tmux.conf'" >> "$HOME/.dotfiles-notes"
+if tmux list-sessions >/dev/null 2>&1; then
+    echo "tmux server is running — reload config with prefix+r or 'tmux source-file ~/.tmux.conf'" >>"$HOME/.dotfiles-notes"
 else
     tmux kill-server || true
 fi
@@ -17,8 +17,8 @@ fi
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
     echo "Installing tmux plugins..."
-    rm -rf $HOME/.tmux/plugins/tpm
-    git clone --depth 1 https://github.com/tmux-plugins/tpm $HOME/.tmux/plugins/tpm
+    rm -rf "$HOME/.tmux/plugins/tpm"
+    git clone --depth 1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
 fi
 
 "$HOME/.tmux/plugins/tpm/bin/install_plugins"

--- a/scripts/30_setup_vim.sh
+++ b/scripts/30_setup_vim.sh
@@ -6,20 +6,20 @@
 echo 'Configuring vim...'
 confirm_binaries "git" "vim" "curl"
 
-mkdir -p $HOME/.vim/autoload $HOME/.vim/bundle $HOME/.vim/.vimswap
+mkdir -p "$HOME/.vim/autoload" "$HOME/.vim/bundle" "$HOME/.vim/.vimswap"
 
-cp -rf "${DOT_ROOT}/files/vim/." $HOME/.vim
-ln -sf $HOME/.vim/vimrc $HOME/.vimrc
+cp -rf "${DOT_ROOT}/files/vim/." "$HOME/.vim"
+ln -sf "$HOME/.vim/vimrc" "$HOME/.vimrc"
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -f "$HOME/.vim/autoload/pathogen.vim" ]; then
-    rm -rf $HOME/.vim/bundle
-    curl -LSso $HOME/.vim/autoload/pathogen.vim https://tpo.pe/pathogen.vim
-    git clone --depth=1 --branch=master https://github.com/dracula/vim.git $HOME/.vim/bundle/dracula
-    git clone --depth=1 --branch=master https://github.com/scrooloose/nerdtree.git $HOME/.vim/bundle/nerdtree
-    git clone --depth=1 --branch=master https://github.com/Xuyuanp/nerdtree-git-plugin.git $HOME/.vim/bundle/nerdtree-git-plugin
-    git clone --depth=1 --branch=master https://tpope.io/vim/surround.git $HOME/.vim/bundle/surround
-    find $HOME/.vim/bundle/ -maxdepth 2 -type d -name '.git' | xargs rm -rf {}
+    rm -rf "$HOME/.vim/bundle"
+    curl -LSso "$HOME/.vim/autoload/pathogen.vim" https://tpo.pe/pathogen.vim
+    git clone --depth=1 --branch=master https://github.com/dracula/vim.git "$HOME/.vim/bundle/dracula"
+    git clone --depth=1 --branch=master https://github.com/scrooloose/nerdtree.git "$HOME/.vim/bundle/nerdtree"
+    git clone --depth=1 --branch=master https://github.com/Xuyuanp/nerdtree-git-plugin.git "$HOME/.vim/bundle/nerdtree-git-plugin"
+    git clone --depth=1 --branch=master https://tpope.io/vim/surround.git "$HOME/.vim/bundle/surround"
+    find "$HOME/.vim/bundle/" -maxdepth 2 -type d -name '.git' -exec rm -rf {} +
 fi
 
 echo "-> vim setup finished"

--- a/scripts/40_setup_git.sh
+++ b/scripts/40_setup_git.sh
@@ -6,13 +6,13 @@
 echo 'Configuring git...'
 confirm_binaries "git"
 
-cp -rf "${DOT_ROOT}/files/git/gitconfig" $HOME/.gitconfig
+cp -rf "${DOT_ROOT}/files/git/gitconfig" "$HOME/.gitconfig"
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -f "$HOME/.zsh/git-completion.bash" ]; then
-    mkdir -p $HOME/.zsh
-    curl -LSso $HOME/.zsh/git-completion.bash https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
-    curl -LSso $HOME/.zsh/completions/_git https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.zsh
+    mkdir -p "$HOME/.zsh"
+    curl -LSso "$HOME/.zsh/git-completion.bash" https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash
+    curl -LSso "$HOME/.zsh/completions/_git" https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.zsh
 fi
 
 echo "-> git setup finished, use 'git alias' to see configured aliases"

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -6,7 +6,8 @@ PASS=0
 FAIL=0
 
 check() {
-    local label="$1"; shift
+    local label="$1"
+    shift
     if "$@" &>/dev/null; then
         echo "PASS: $label"
         PASS=$((PASS + 1))
@@ -19,6 +20,17 @@ check() {
 # Shell scripts — bash syntax check
 for f in "$ROOT"/scripts/*.sh; do
     check "bash -n scripts/$(basename "$f")" bash -n "$f"
+done
+
+# shfmt — formatting check (.sh files only)
+for f in "$ROOT"/scripts/*.sh "$ROOT"/docker/*.sh "$ROOT"/tests/lint.sh; do
+    check "shfmt: $(basename "$f")" shfmt -d -i 4 "$f"
+done
+
+# static analysis — .sh files only, skipping _config.sh (zsh shebang)
+for f in "$ROOT"/scripts/*.sh "$ROOT"/docker/*.sh "$ROOT"/tests/lint.sh; do
+    [ "$(basename "$f")" = "_config.sh" ] && continue
+    check "shellcheck: $(basename "$f")" shellcheck --exclude=SC1091 "$f"
 done
 
 # Zsh config files


### PR DESCRIPTION
## Summary

- Add `shfmt` (4-space indent) formatting check for all `.sh` files
- Add `shellcheck` static analysis for `.sh` files; `_config.sh` excluded (zsh shebang)
- Fix all shellcheck findings: unquoted `$HOME`, `&>` in POSIX sh, unsafe `find | xargs`
- Add `shfmt` and `shellcheck` to the Dockerfile so `make lint` works inside the container

## Test plan

- [ ] `make lint` passes locally (43/43)
- [ ] `make docker-build && make docker-run` → `make lint` passes inside container
- [ ] Intentionally misformat a `.sh` file — `make lint` fails on shfmt check
- [ ] Introduce an unquoted variable — `make lint` fails on shellcheck

🤖 Generated with [Claude Code](https://claude.com/claude-code)