### PR TITLE
Fix zshrc Go block: use go env GOROOT instead of brew --prefix golang

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,7 +64,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
 - [ ] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
-- [ ] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
+- [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
 - [ ] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
 - [x] Fix `zshrc` FZF_CTRL_T_COMMAND — uses `fd` unconditionally; broken on Linux without the Docker `fd→fdfind` symlink. <!-- agent-safe -->

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -58,7 +58,7 @@ fi
 
 # golang
 if command -v go &> /dev/null; then
-  export GOROOT="$(brew --prefix golang)/libexec"
+  export GOROOT="$(go env GOROOT)"
   export GOPATH="$HOME/go"
   export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"
 fi


### PR DESCRIPTION
## Summary

Closes #31

- Replaces `$(brew --prefix golang)/libexec` with `$(go env GOROOT)` in the Go block of `files/zsh/zshrc`
- `go env GOROOT` works correctly regardless of OS or how Go was installed (Homebrew, official installer, asdf, mise, etc.)
- The existing `command -v go` guard is kept, so the block is still skipped when Go is not installed

## Changes

```diff
 if command -v go &> /dev/null; then
-  export GOROOT="$(brew --prefix golang)/libexec"
+  export GOROOT="$(go env GOROOT)"
   export GOPATH="$HOME/go"
   export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"
 fi
```

## Test plan

- [ ] Open a new shell on macOS with Go installed via Homebrew — `go` tooling should still work
- [ ] Open a new shell on Linux with Go installed — `go` tooling should now work (previously broken)
- [ ] Open a new shell without Go installed — block is skipped cleanly

**Please review before merging.**