### PR TITLE
Fix zshrc terraform completion — guard hardcoded path with existence check

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -96,5 +96,7 @@ else
 fi;
 
 autoload -U +X bashcompinit && bashcompinit
-complete -o nospace -C /opt/homebrew/bin/terraform terraform
+if command -v terraform &>/dev/null; then
+  complete -o nospace -C "$(command -v terraform)" terraform
+fi
 complete -C aws_completer aws


### PR DESCRIPTION
Closes #33

## What changed

`files/zsh/zshrc` previously registered terraform tab completion unconditionally via a hardcoded Homebrew path:

```zsh
complete -o nospace -C /opt/homebrew/bin/terraform terraform
```

This errors on every interactive shell start when terraform is not installed, or is installed somewhere other than `/opt/homebrew/bin/` (Linux, Intel Macs, `tfenv`/`asdf` installs).

The fix wraps the call in a `command -v` guard and resolves the path dynamically:

```zsh
if command -v terraform &>/dev/null; then
  complete -o nospace -C "$(command -v terraform)" terraform
fi
```

## Testing

- `make lint` passes with the same results as the baseline (pre-existing failures only, no regressions introduced).
- Pattern matches the existing `command -v` guard style already used for `aws`, `go`, `fd`, and `fzf` in the same file.

## Review notes

Marked as draft — please review before merging.
