### PR TITLE
Fix zshrc fpath: guard stale Intel Homebrew path with existence check

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
 - [ ] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
 - [x] Fix `zshrc` FZF_CTRL_T_COMMAND — uses `fd` unconditionally; broken on Linux without the Docker `fd→fdfind` symlink. <!-- agent-safe -->
-- [ ] Fix `zshrc` fpath — includes stale Intel Homebrew path (`/usr/local/share/zsh/site-functions`); should be guarded or replaced. <!-- agent-safe -->
+- [x] Fix `zshrc` fpath — includes stale Intel Homebrew path (`/usr/local/share/zsh/site-functions`); should be guarded or replaced. <!-- agent-safe -->
 - [ ] Fix `scripts/20_setup_tmux.sh` — `tmux kill-server` fires when `list-sessions` fails, which also happens when a server is running but has no sessions.
 - [ ] Fix `gitconfig` hardcoded user identity — `name`/`email` silently overwrite git config on any machine running `make install`.
 - [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -11,7 +11,7 @@ export ZSH=$HOME/.oh-my-zsh
 export KEYTIMEOUT=5
 ZSH_THEME=""
 plugins=(zsh-autosuggestions zsh-syntax-highlighting)
-fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions $fpath)
+fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions(/N) $fpath)
 source $ZSH/oh-my-zsh.sh
 
 # zsh-autosuggest


### PR DESCRIPTION
## Summary

Closes #35

- Adds a `(/N)` glob qualifier to `/usr/local/share/zsh/site-functions` in `fpath` so it is only included when the directory actually exists
- Prevents dead-path noise on Apple Silicon Macs (where Homebrew lives at `/opt/homebrew`) and Linux (where this path doesn't exist at all)
- Uses idiomatic zsh: `(/N)` means "match only directories, null-glob if no match"

## Change

```zsh
# before
fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions $fpath)

# after
fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions(/N) $fpath)
```

## Test plan

- [ ] Source `~/.zshrc` on Apple Silicon Mac — verify no error, Intel path absent from `$fpath`
- [ ] Source `~/.zshrc` on Intel Mac with Homebrew at `/usr/local` — verify Intel path present in `$fpath`
- [ ] Run `make install` in Docker container (Linux) — verify no fpath-related errors

https://claude.ai/code/session_018xdyxunDwi3XJx33NkeouX