### PR TITLE
Fix AWS CLI tab completion: add `command -v aws_completer` guard

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Add `tmux-ssh` function — SSH into a home network machine and attach to tmux (or create a new session if none running). Usage: `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`.
 - [x] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`. <!-- agent-safe -->
 - [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only). <!-- agent-safe -->
-- [ ] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
+- [x] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
 - [ ] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
 - [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -99,4 +99,6 @@ autoload -U +X bashcompinit && bashcompinit
 if command -v terraform &>/dev/null; then
   complete -o nospace -C "$(command -v terraform)" terraform
 fi
-complete -C aws_completer aws
+if command -v aws_completer &>/dev/null; then
+  complete -C aws_completer aws
+fi


### PR DESCRIPTION
Closes #37

## What changed

`zshrc` was unconditionally calling `complete -C aws_completer aws` at shell startup. On machines without AWS CLI installed, this registers broken tab completion for `aws` silently.

**Before:**
```zsh
complete -C aws_completer aws
```

**After:**
```zsh
if command -v aws_completer &>/dev/null; then
  complete -C aws_completer aws
fi
```

This matches the guard style already used for terraform, fzf, go, and other optional tools in the same file.

Also marks the corresponding TODO in `CLAUDE.md` as done.

## Testing

- Pre-existing lint failures (31) are unchanged — the failure count is the same on `main`.
- The change is a straightforward guard addition with no logic change when `aws_completer` is present.

---

Ready for human review — please do not auto-merge.