### PR TITLE
Mark terraform completion TODO as done in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,7 +62,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [x] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`. <!-- agent-safe -->
 - [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only). <!-- agent-safe -->
 - [x] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
-- [ ] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
+- [x] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
 - [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->


### PR DESCRIPTION
## Summary

- The `zshrc` terraform completion fix (replacing the hardcoded `/opt/homebrew/bin/terraform` path with a `command -v` guard) was already merged in commit `147a895` via PR #34.
- CLAUDE.md still listed the item as unchecked (`[ ]`), so this PR marks it done (`[x]`).

Closes #39.

## Test plan

- [ ] Verify `CLAUDE.md` shows the terraform completion TODO as `[x]`
- [ ] Verify `files/zsh/zshrc` still has the `command -v terraform` guard at line 99

> Needs human review before merge.