### PR TITLE
Fix zshenv Homebrew init to support Intel Macs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,7 +66,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
 - [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
 - [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
-- [ ] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
+- [x] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
 - [x] Fix `zshrc` FZF_CTRL_T_COMMAND — uses `fd` unconditionally; broken on Linux without the Docker `fd→fdfind` symlink. <!-- agent-safe -->
 - [x] Fix `zshrc` fpath — includes stale Intel Homebrew path (`/usr/local/share/zsh/site-functions`); should be guarded or replaced. <!-- agent-safe -->
 - [ ] Fix `scripts/20_setup_tmux.sh` — `tmux kill-server` fires when `list-sessions` fails, which also happens when a server is running but has no sessions.

--- a/files/zsh/zshenv
+++ b/files/zsh/zshenv
@@ -7,6 +7,8 @@ export TERM="xterm-256color"
 # Homebrew - must live here so PATH is set for ALL shell types including non-login shells invoked over SSH
 if [ -x "/opt/homebrew/bin/brew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
 fi
 
 # set PATH so it includes user's private bin if it exists


### PR DESCRIPTION
## Summary

Closes #41.

- `files/zsh/zshenv` previously only checked `/opt/homebrew/bin/brew` (Apple Silicon path), so Homebrew was silently skipped on Intel Macs
- Add an `elif` branch for `/usr/local/bin/brew` to cover the Intel prefix
- Linux is unaffected — neither path exists there

## Change

```diff
 if [ -x "/opt/homebrew/bin/brew" ]; then
     eval "$(/opt/homebrew/bin/brew shellenv)"
+elif [ -x "/usr/local/bin/brew" ]; then
+    eval "$(/usr/local/bin/brew shellenv)"
 fi
```

## Test plan

- [ ] On Apple Silicon Mac: verify `brew` is still on PATH after sourcing `.zshenv`
- [ ] On Intel Mac: verify `brew` is now on PATH after sourcing `.zshenv`
- [ ] On Linux: verify no error is produced (neither path exists)

> Needs human review before merge.

https://claude.ai/code/session_01G1o4sUPU5yMQrzKRmqLfpG