### PR TITLE
Fix 50_setup_vscode.sh — use OS-aware path for VS Code settings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [x] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
 - [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
-- [ ] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
+- [x] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
 - [ ] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
 - [x] Fix `zshrc` FZF_CTRL_T_COMMAND — uses `fd` unconditionally; broken on Linux without the Docker `fd→fdfind` symlink. <!-- agent-safe -->
 - [x] Fix `zshrc` fpath — includes stale Intel Homebrew path (`/usr/local/share/zsh/site-functions`); should be guarded or replaced. <!-- agent-safe -->

--- a/scripts/50_setup_vscode.sh
+++ b/scripts/50_setup_vscode.sh
@@ -9,7 +9,16 @@ echo "$script_dir"
 
 . "$script_dir/_config.sh"
 
-mkdir -p "$HOME/Library/Application Support/Code/User"
-cp -f "$DOT_ROOT/files/vscode/settings.json" "$HOME/Library/Application Support/Code/User"
+if [ "$DOT_OS" = "darwin" ]; then
+    vscode_user_dir="$HOME/Library/Application Support/Code/User"
+elif [ "$DOT_OS" = "linux" ]; then
+    vscode_user_dir="$HOME/.config/Code/User"
+else
+    echo "Unsupported OS '$DOT_OS', skipping vscode setup."
+    exit 0
+fi
+
+mkdir -p "$vscode_user_dir"
+cp -f "$DOT_ROOT/files/vscode/settings.json" "$vscode_user_dir"
 
 echo 'Done configuring vscode.'


### PR DESCRIPTION
## Summary

Closes #44.

- `scripts/50_setup_vscode.sh` previously hardcoded `~/Library/Application Support/Code/User`, the macOS-specific VS Code settings path
- On Linux, VS Code uses `~/.config/Code/User`; running `make install` on Linux would silently write to the wrong location
- Added an OS guard using `$DOT_OS` (set by `scripts/_config.sh`) to select the correct path per platform; unsupported OSes skip the step gracefully

## Changes

- `scripts/50_setup_vscode.sh` — replaced hardcoded path with `if/elif` on `$DOT_OS`
- `CLAUDE.md` — marked TODO as completed

## Test plan

- [ ] Run `make install` on macOS — settings.json copied to `~/Library/Application Support/Code/User`
- [ ] Run `make install` (or Docker `make install`) on Linux — settings.json copied to `~/.config/Code/User`
- [ ] Run `make lint` — no new failures introduced by this change

https://claude.ai/code/session_01Q3TFzA19ErioWhbGy7wLMs

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q3TFzA19ErioWhbGy7wLMs)_