### PR TITLE
Add oh-my-zsh Makefile plugin for cleaner make tab completion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - [ ] Migrate TODO list from CLAUDE.md to GitHub issues for easier tracking without PRs.
 - [ ] Add `tmux-ssh` function — SSH into a home network machine and attach to tmux (or create a new session if none running). Usage: `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`.
 - [x] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`. <!-- agent-safe -->
-- [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only). <!-- agent-safe -->
+- [x] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only). <!-- agent-safe -->
 - [x] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
 - [x] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
 - [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ My dotfiles for macOS and Linux.
 
 ## Tools configured
 
-- **zsh** — shell config, aliases, functions, completions, oh-my-zsh plugins (fzf, autosuggestions, syntax highlighting)
+- **zsh** — shell config, aliases, functions, completions, oh-my-zsh plugins (fzf, autosuggestions, syntax highlighting, Makefile)
 - **starship** — shell prompt
 - **tmux** — terminal multiplexer
 - **vim** — editor

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -10,7 +10,7 @@ export ZSH_HOME=$HOME/.zsh
 export ZSH=$HOME/.oh-my-zsh
 export KEYTIMEOUT=5
 ZSH_THEME=""
-plugins=(zsh-autosuggestions zsh-syntax-highlighting)
+plugins=(zsh-autosuggestions zsh-syntax-highlighting Makefile)
 fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions(/N) $fpath)
 source $ZSH/oh-my-zsh.sh
 


### PR DESCRIPTION
## Summary

- Adds the bundled oh-my-zsh `Makefile` plugin to `plugins=(...)` in `files/zsh/zshrc`
- The plugin provides tab completion that lists only real make targets (not internal/phony ones)
- Marks the corresponding TODO in `CLAUDE.md` as done

Closes #46

## Test plan

- [ ] After `make install`, open a new shell and type `make <TAB>` — verify only real targets from the repo's Makefile are shown
- [ ] Confirm existing oh-my-zsh plugins (`zsh-autosuggestions`, `zsh-syntax-highlighting`) still work normally

https://claude.ai/code/session_01QLXdGxJrfwb7MmVyExgytt

---
_Generated by [Claude Code](https://claude.ai/code/session_01QLXdGxJrfwb7MmVyExgytt)_