### PR TITLE
Migrate TODO tracking from CLAUDE.md to GitHub Issues

### DIFF
--- a/.claude/commands/todo.md
+++ b/.claude/commands/todo.md
@@ -1,13 +1,15 @@
 ---
-description: Add a new TODO item to CLAUDE.md
+description: Create a new GitHub issue as a TODO item
 disable-model-invocation: true
 ---
 
-Add a new TODO item to CLAUDE.md.
+Create a new GitHub issue as a TODO item.
 
 The user wants to add this TODO: $ARGUMENTS
 
-1. Read CLAUDE.md
-2. Add `- [ ] $ARGUMENTS` as a new item in the `## TODO` section
-3. Keep it concise and consistent with existing TODO items
-4. Confirm the item was added
+Run:
+```
+gh issue create --title "$ARGUMENTS" --label todo --assignee "@me" --body ""
+```
+
+Then confirm with the issue URL.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,8 @@
+---
+allowed-tools: Bash(git:*), Bash(gh:*)
+---
+# Open PR
+1. Ensure on a feature branch (create one from main if not)
+2. Run tests/linters
+3. Push branch
+4. Open PR with `gh pr create` using a conventional-commit title

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,21 +58,4 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 
 ## TODO
 
-- [ ] Investigate failing lint on scheduled CI task.
-- [ ] Update scheduled task to create non-draft PRs assigned to me.
-- [ ] Migrate TODO list from CLAUDE.md to GitHub issues for easier tracking without PRs.
-- [ ] Add `tmux-ssh` function — SSH into a home network machine and attach to tmux (or create a new session if none running). Usage: `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`.
-- [x] Fix `tmux.conf` clipboard — `pbcopy` is macOS-only; Linux needs `xclip` or `wl-copy`. <!-- agent-safe -->
-- [ ] Add oh-my-zsh `Makefile` plugin for cleaner make tab completion (targets only). <!-- agent-safe -->
-- [x] Enable/fix AWS CLI tab completion — add `command -v aws_completer` guard in `zshrc`; currently registers broken completion if `aws_completer` is not on PATH. <!-- agent-safe -->
-- [x] Fix `zshrc` terraform completion — hardcoded `/opt/homebrew/bin/terraform` with no existence check; errors on every shell start if not installed. <!-- agent-safe -->
-- [ ] Enable/fix kubectl tab completion — not currently configured in `zshrc`.
-- [x] Fix `zshrc` Go block — replace `brew --prefix golang` with `go env GOROOT`; current form fails on Linux. <!-- agent-safe -->
-- [x] Fix `50_setup_vscode.sh` — hardcodes `~/Library/Application Support/Code/User` with no OS guard; will fail on Linux. <!-- agent-safe -->
-- [ ] Fix `zshenv` Homebrew init — only checks Apple Silicon path (`/opt/homebrew`); Intel Macs (`/usr/local`) silently get no Homebrew on PATH. <!-- agent-safe -->
-- [x] Fix `zshrc` FZF_CTRL_T_COMMAND — uses `fd` unconditionally; broken on Linux without the Docker `fd→fdfind` symlink. <!-- agent-safe -->
-- [x] Fix `zshrc` fpath — includes stale Intel Homebrew path (`/usr/local/share/zsh/site-functions`); should be guarded or replaced. <!-- agent-safe -->
-- [ ] Fix `scripts/20_setup_tmux.sh` — `tmux kill-server` fires when `list-sessions` fails, which also happens when a server is running but has no sessions.
-- [ ] Fix `gitconfig` hardcoded user identity — `name`/`email` silently overwrite git config on any machine running `make install`.
-- [ ] Make the Docker image reusable as a generic development container (e.g. configurable base image, dev tools, volume mounts).
-- [ ] Add support and documentation for tmux window movement.
+Tracked as GitHub issues with the `todo` label: `gh issue list --label todo`


### PR DESCRIPTION
## Summary
- Replaces the TODO section in `CLAUDE.md` with a pointer to GitHub Issues (label: `todo`)
- Updates `/todo` skill to create issues via `gh issue create` instead of editing `CLAUDE.md`
- Migrates all existing TODOs to issues #48–#56; tags existing #46
- Creates `agent-safe` label and applies to #46 and #53 (replacing `<!-- agent-safe -->` HTML comments)

## Test plan
- [ ] `/todo some new item` creates a GitHub issue with `todo` label assigned to me
- [ ] `gh issue list --label todo` shows the full backlog
- [ ] `gh issue list --label agent-safe` shows #46 and #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)