### PR TITLE
feat: add uv aliases for python/pip

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,8 +1,0 @@
-{
-    "mcpServers": {
-        "github": {
-            "command": "npx",
-            "args": ["-y", "@modelcontextprotocol/server-github"]
-        }
-    }
-}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,6 +24,7 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --yes
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
 RUN useradd --create-home --shell /bin/zsh jan && echo "jan:docker" | chpasswd && adduser jan sudo
 USER jan:jan

--- a/files/shell/aliases
+++ b/files/shell/aliases
@@ -22,3 +22,9 @@ if [[ "${PLATFORM}" == "linux" ]]; then
 elif [[ "${PLATFORM}" == "darwin" ]]; then
     alias ls='ls -laG'
 fi
+
+if command -v uv &>/dev/null; then
+    alias python='uv run python'
+    alias python3='uv run python'
+    alias pip='uv pip'
+fi

--- a/files/starship/starship.toml
+++ b/files/starship/starship.toml
@@ -6,3 +6,6 @@ error_symbol = '[](bold red) '
 
 [kubernetes]
 disabled = false
+
+[python]
+python_binary = [["uv", "run", "--no-python-downloads", "python"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "dotfiles"
 version = "0.1.0"
-description = "Add your description here"
+description = "Dotfiles for MacOS and Linux"
 readme = "README.md"
 requires-python = ">=3.14"
 dependencies = []

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,8 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"
+
+[[package]]
+name = "dotfiles"
+version = "0.1.0"
+source = { virtual = "." }


### PR DESCRIPTION
## Summary
- Adds `python`, `python3`, and `pip` aliases that delegate to `uv run python` / `uv pip`
- Guards aliases with `command -v uv` so they don't break on systems without uv
- Removes `.mcp.json` (project-level GitHub MCP server — not needed, `gh` CLI covers the same ground)
- Updates `pyproject.toml` description; commits `uv.lock`

## Test plan
- [ ] Verify aliases work on a machine with uv installed
- [ ] Verify shell sources cleanly on a machine without uv (aliases not defined, no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)