### PR TITLE
Fix gitconfig hardcoded user identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ My dotfiles for macOS and Linux.
 - **starship** — shell prompt
 - **tmux** — terminal multiplexer
 - **vim** — editor
-- **git** — global config
+- **git** — global config (prompts for `user.name`/`user.email` if not already set; never overwrites existing identity)
 - **vscode** — editor settings
 
 ## Setup

--- a/files/git/gitconfig
+++ b/files/git/gitconfig
@@ -37,6 +37,3 @@
   ff = only
 [push]
 	default = current
-[user]
-	name = Jan Groth
-	email = jan.groth.de@gmail.com

--- a/scripts/40_setup_git.sh
+++ b/scripts/40_setup_git.sh
@@ -6,7 +6,32 @@
 echo 'Configuring git...'
 confirm_binaries "git"
 
+# Read existing user identity before overwriting ~/.gitconfig
+_git_name=$(git config --global user.name 2>/dev/null || true)
+_git_email=$(git config --global user.email 2>/dev/null || true)
+
 cp -rf "${DOT_ROOT}/files/git/gitconfig" "$HOME/.gitconfig"
+
+# Restore preserved identity; prompt only for values that were not set
+if [ -n "$_git_name" ]; then
+    git config --global user.name "$_git_name"
+fi
+if [ -n "$_git_email" ]; then
+    git config --global user.email "$_git_email"
+fi
+if [ -z "$_git_name" ] || [ -z "$_git_email" ]; then
+    echo "Git user identity not configured."
+    if [ -z "$_git_name" ]; then
+        printf "  Enter your git user.name (leave blank to skip): "
+        read -r _input_name
+        [ -n "$_input_name" ] && git config --global user.name "$_input_name"
+    fi
+    if [ -z "$_git_email" ]; then
+        printf "  Enter your git user.email (leave blank to skip): "
+        read -r _input_email
+        [ -n "$_input_email" ] && git config --global user.email "$_input_email"
+    fi
+fi
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -f "$HOME/.zsh/git-completion.bash" ]; then


### PR DESCRIPTION
## Summary

- Remove hardcoded `[user]` section (`name`/`email`) from `files/git/gitconfig` template
- Update `scripts/40_setup_git.sh` to read existing identity before overwriting `~/.gitconfig`, restore it afterwards, and prompt interactively only when values are missing
- Update README to document the new behaviour

## Test plan

- [ ] Fresh machine with no `~/.gitconfig`: `make install` prompts for `user.name` and `user.email`
- [ ] Machine with existing identity: `make install` preserves existing `user.name` and `user.email` without prompting
- [ ] Partial config (only `user.name` set): `make install` prompts only for the missing `user.email`
- [ ] `bash -n scripts/40_setup_git.sh` passes (syntax check)
- [ ] `git config --file files/git/gitconfig --list` passes (valid gitconfig)

Closes #53

https://claude.ai/code/session_01Luo86E3Ny7QfhYNnL7Rhfo

---
_Generated by [Claude Code](https://claude.ai/code/session_01Luo86E3Ny7QfhYNnL7Rhfo)_