### PR TITLE
fix: don't overwrite git user identity on make install

### DIFF
--- a/files/git/gitconfig
+++ b/files/git/gitconfig
@@ -37,6 +37,3 @@
   ff = only
 [push]
 	default = current
-[user]
-	name = Jan Groth
-	email = jan.groth.de@gmail.com

--- a/scripts/40_setup_git.sh
+++ b/scripts/40_setup_git.sh
@@ -6,7 +6,27 @@
 echo 'Configuring git...'
 confirm_binaries "git"
 
+# Preserve existing user identity before overwriting gitconfig
+_git_name=$(git config --global user.name 2>/dev/null || true)
+_git_email=$(git config --global user.email 2>/dev/null || true)
+
 cp -rf "${DOT_ROOT}/files/git/gitconfig" "$HOME/.gitconfig"
+
+# Restore previously set identity; prompt when running interactively
+if [ -n "$_git_name" ]; then
+    git config --global user.name "$_git_name"
+elif [ -t 0 ]; then
+    printf 'git user.name (leave blank to skip): '
+    IFS= read -r _git_name
+    [ -n "$_git_name" ] && git config --global user.name "$_git_name"
+fi
+if [ -n "$_git_email" ]; then
+    git config --global user.email "$_git_email"
+elif [ -t 0 ]; then
+    printf 'git user.email (leave blank to skip): '
+    IFS= read -r _git_email
+    [ -n "$_git_email" ] && git config --global user.email "$_git_email"
+fi
 
 # update remote dependencies
 if [ -n "$DOT_FORCE" ] || [ ! -f "$HOME/.zsh/git-completion.bash" ]; then


### PR DESCRIPTION
## Problem

Running `make install` (or `./scripts/40_setup_git.sh`) silently overwrote `~/.gitconfig` with a hardcoded `[user]` block containing `Jan Groth`'s name and email, breaking identity on any other machine.

## Changes

- **`files/git/gitconfig`** — removed hardcoded `[user]` section
- **`scripts/40_setup_git.sh`** — before copying gitconfig, reads existing `user.name`/`user.email` from the global config; after copying, restores them. If no identity was set and stdin is a terminal, prompts the user to enter values (blank = skip).

## Behaviour

| Scenario | Result |
|---|---|
| Identity already in `~/.gitconfig` | Preserved unchanged |
| No identity, interactive terminal | Prompted for name and email |
| No identity, non-interactive (CI/Docker) | Skipped silently — user sets manually |

Closes #53

---
_Generated by [Claude Code](https://claude.ai/code/session_01KzmXNoVfF8W2D9UFah1Sax)_