### PR TITLE
Add tmux-ssh function — SSH into host and attach or create tmux session

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ make install
 
 - `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
-- `tmux-ssh <host>` — SSH into a machine and attach to an existing tmux session, or create a new one if none is running (e.g. `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`)
+- `tmux-ssh <host>` — SSH into a host and attach to an existing tmux session (or create one named `main`)

--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ make install
 
 - `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
+- `tmux-ssh <host>` — SSH into a machine and attach to an existing tmux session, or create a new one if none is running (e.g. `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`)

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ make install
 
 - `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
-- `tmux-ssh <host>` — SSH into a host and attach to an existing tmux session (or create one named `main`)
+- `tmux-ssh <host>` — SSH into a host and attach to an existing tmux session (named `main`) or create one if none exists

--- a/README.md
+++ b/README.md
@@ -60,4 +60,4 @@ make install
 
 - `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
-- `tmux-ssh <host>` — SSH into a host and attach to an existing tmux session (named `main`) or create one if none exists
+- `tmux-ssh <host>` — SSH into a machine and attach to (or create) a tmux session named `main`

--- a/files/help/tmux
+++ b/files/help/tmux
@@ -19,12 +19,7 @@
 
 Within the session list (`prefix + s`): `x` to delete, `t` to tag.
 
-Attach to a remote tmux over SSH:
-```sh
-ssh darth.local -t "/opt/homebrew/bin/tmux attach"
-```
-
-Use `tmux-ssh` to SSH into a host and attach to (or create) a tmux session:
+Attach to a remote tmux over SSH (attach existing session or create new):
 ```sh
 tmux-ssh kylo
 tmux-ssh 192.168.86.201

--- a/files/help/tmux
+++ b/files/help/tmux
@@ -24,6 +24,12 @@ Attach to a remote tmux over SSH:
 ssh darth.local -t "/opt/homebrew/bin/tmux attach"
 ```
 
+Use `tmux-ssh` to SSH into a host and attach to (or create) a tmux session:
+```sh
+tmux-ssh kylo
+tmux-ssh 192.168.86.201
+```
+
 ## Windows
 
 | Key            | Action                                 |

--- a/files/help/tmux
+++ b/files/help/tmux
@@ -19,7 +19,7 @@
 
 Within the session list (`prefix + s`): `x` to delete, `t` to tag.
 
-Attach to a remote tmux over SSH (attach existing session or create new):
+Attach to (or create) a tmux session on a remote machine:
 ```sh
 tmux-ssh kylo
 tmux-ssh 192.168.86.201
@@ -39,7 +39,7 @@ tmux-ssh 192.168.86.201
 ## Panes
 
 | Key                | Action                                  |
-|--------------------|-----------------------------------------|
+|--------------------|------------------------------------------|
 | `prefix + \|`      | Split horizontally (keeps current path) |
 | `prefix + -`       | Split vertically (keeps current path)   |
 | `prefix + h/j/k/l` | Move between panes (vi-style)           |

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,0 +1,7 @@
+tmux-ssh() {
+    if [[ -z "${1:-}" ]]; then
+        print "Usage: tmux-ssh <host>"
+        return 1
+    fi
+    ssh -t "$1" 'tmux attach || tmux new-session'
+}

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,7 +1,7 @@
-function tmux-ssh() {
+tmux-ssh() {
     if [[ -z "${1:-}" ]]; then
-        echo "Usage: tmux-ssh <host>"
+        print "Usage: tmux-ssh <host>"
         return 1
     fi
-    ssh "$1" -t "tmux new-session -A -s main"
+    ssh -t "$1" "tmux new-session -A -s main"
 }

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,7 +1,7 @@
-tmux-ssh() {
+function tmux-ssh() {
     if [[ -z "${1:-}" ]]; then
-        print "Usage: tmux-ssh <host>"
+        echo "Usage: tmux-ssh <host>"
         return 1
     fi
-    ssh -t "$1" 'tmux attach || tmux new-session'
+    ssh "$1" -t "tmux new-session -A -s main"
 }

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,6 +1,6 @@
 tmux-ssh() {
     if [[ -z "${1:-}" ]]; then
-        print "Usage: tmux-ssh <host>"
+        echo "Usage: tmux-ssh <host>"
         return 1
     fi
     ssh -t "$1" "tmux new-session -A -s main"

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,7 +1,4 @@
 tmux-ssh() {
-    if [[ -z "${1:-}" ]]; then
-        echo "Usage: tmux-ssh <host>"
-        return 1
-    fi
-    ssh -t "$1" "tmux new-session -A -s main"
+    local host="${1:?Usage: tmux-ssh <host>}"
+    ssh -t "$host" 'tmux new-session -A -s main'
 }


### PR DESCRIPTION
## Summary

- Adds `tmux-ssh <host>` shell function to `files/shell/functions/tmux-ssh`
- Uses `tmux new-session -A -s main`: attaches to an existing `main` session if one exists, otherwise creates a new one
- Updates `README.md` to document the new helper function
- Updates `files/help/tmux` (shown via `dfh tmux`) with `tmux-ssh` usage examples, replacing the raw SSH one-liner

## Usage

```sh
tmux-ssh kylo
tmux-ssh 192.168.86.201
```

## Test plan

- [ ] Run `make install` and verify `tmux-ssh` is available in zsh
- [ ] `tmux-ssh <host>` on a machine with no existing tmux session — should create one named `main`
- [ ] `tmux-ssh <host>` on a machine with an existing `main` session — should attach to it
- [ ] `tmux-ssh` with no argument — should print usage and exit 1
- [ ] `dfh tmux` shows updated Sessions section with `tmux-ssh` examples

Closes #50