### PR TITLE
Replace bat with glow for rendering dotfiles help pages

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,11 +4,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # Locales
 ENV LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
 RUN apt-get update && apt-get install -y \
-    bat \
     curl \
     fd-find \
     fontconfig \
     git \
+    gpg \
     locales \
     make \
     python3 \
@@ -21,6 +21,12 @@ RUN apt-get update && apt-get install -y \
     wget \
     zsh \
     && locale-gen en_US.UTF-8 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/apt/keyrings \
+    && curl -fsSL https://repo.charm.sh/apt/gpg.key | gpg --dearmor -o /etc/apt/keyrings/charm.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/charm.gpg] https://repo.charm.sh/apt/ * *" > /etc/apt/sources.list.d/charm.list \
+    && apt-get update && apt-get install -y glow \
     && rm -rf /var/lib/apt/lists/*
 
 RUN sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --yes
@@ -36,8 +42,7 @@ RUN wget -P /home/jan/.local/share/fonts https://github.com/ryanoasis/nerd-fonts
     && fc-cache -fv
 
 RUN mkdir -p ~/.local/bin \
-    && ln -s $(which fdfind) ~/.local/bin/fd \
-    && ln -s $(which batcat) ~/.local/bin/bat
+    && ln -s $(which fdfind) ~/.local/bin/fd
 
 RUN touch /home/jan/.zshrc
 

--- a/files/shell/functions/dfh
+++ b/files/shell/functions/dfh
@@ -21,8 +21,8 @@ dfh() {
         return 1
     fi
 
-    if command -v bat &>/dev/null; then
-        bat --language=md --style=header,grid --color=always "$page"
+    if command -v glow &>/dev/null; then
+        glow "$page"
     else
         cat "$page"
     fi


### PR DESCRIPTION
## Summary

- Replaces `bat` with `glow` in the `dfh` shell function for rendering markdown help pages
- Installs `glow` in the Docker image via the charm.sh apt repository (requires adding `gpg` to the base apt install and setting up the charm.sh apt key/source)
- Removes the `batcat → bat` symlink from the Dockerfile since `bat` is no longer needed

Closes #59

https://claude.ai/code/session_015LQcdzwRKJASyuw3pgJnVJ

---
_Generated by [Claude Code](https://claude.ai/code/session_015LQcdzwRKJASyuw3pgJnVJ)_