### PR TITLE
Add tmux-ssh helper function

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,4 @@ make install
 
 - `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
+- `tmux-ssh <host>` — SSH into a machine and attach to (or create) a tmux session named `main`; e.g. `tmux-ssh kylo` or `tmux-ssh 192.168.86.201`

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,0 +1,4 @@
+function tmux-ssh() {
+    local host="${1:?Usage: tmux-ssh <host>}"
+    ssh "$host" -t "tmux new-session -A -s main"
+}


### PR DESCRIPTION
## Summary

- Adds `tmux-ssh <host>` shell function to `files/shell/functions/tmux-ssh`
- SSHes into the given host and attaches to (or creates) a tmux session named `main` via `tmux new-session -A -s main`
- Updates `README.md` to document the new helper function

## Usage

```sh
tmux-ssh kylo
tmux-ssh 192.168.86.201
```

## Test plan

- [ ] Run `make install` and verify `tmux-ssh` is available in a new shell
- [ ] `tmux-ssh <host>` on a machine with no active tmux sessions — should create a new session named `main`
- [ ] `tmux-ssh <host>` on a machine with an existing `main` session — should attach to it
- [ ] `tmux-ssh` with no argument — should print usage error

Closes #50

---
_Generated by [Claude Code](https://claude.ai/code/session_01GGWXWKRoaY6RyU3Kfbpmst)_