### PR TITLE
feat: add tmux-ssh function

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,5 +58,6 @@ make install
 
 ## Helper functions
 
-- `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
 - `dfh [topic]` — dotfiles help; run `dfh` for version info and available topics, `dfh tmux` / `dfh fzf` / `dfh vim` for keybinding references extracted from config files
+- `pro [path]` — jump to a project directory under `$PROJECTS_HOME` (`~/Projects` on macOS, `~` on Linux), with tab completion for nested paths
+- `tmux-ssh <host>` — SSH into a machine and attach to (or create) a tmux session named `main`

--- a/files/help/tmux
+++ b/files/help/tmux
@@ -19,9 +19,10 @@
 
 Within the session list (`prefix + s`): `x` to delete, `t` to tag.
 
-Attach to a remote tmux over SSH:
+Attach to (or create) a tmux session on a remote machine:
 ```sh
-ssh darth.local -t "/opt/homebrew/bin/tmux attach"
+tmux-ssh kylo
+tmux-ssh 192.168.86.201
 ```
 
 ## Windows

--- a/files/shell/functions/tmux-ssh
+++ b/files/shell/functions/tmux-ssh
@@ -1,0 +1,4 @@
+tmux-ssh() {
+    local host="${1:?Usage: tmux-ssh <host>}"
+    ssh -t "$host" 'tmux new-session -A -s main'
+}


### PR DESCRIPTION
## Summary
- Adds `tmux-ssh <host>` shell function — SSHes into a machine and attaches to (or creates) a tmux session named `main`
- Updates `files/help/tmux` with `tmux-ssh` usage examples
- Updates `README.md` with `tmux-ssh` description

Closes #50

## Usage
```sh
tmux-ssh kylo          # requires ~/.ssh/config Host entry
tmux-ssh kylo.local
tmux-ssh 192.168.86.201
```

## Test plan
- [ ] `tmux-ssh kylo` — attaches to existing `main` session
- [ ] `tmux-ssh kylo` with no existing session — creates new `main` session
- [ ] `tmux-ssh` with no argument — prints usage error
- [ ] `tmux-ssh unreachable-host` — SSH fails cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)