### PR TITLE
Remove leftover debug echo lines from setup scripts

### DIFF
--- a/scripts/10_setup_zsh.sh
+++ b/scripts/10_setup_zsh.sh
@@ -4,9 +4,6 @@
 script_path=$(realpath "$0")
 script_dir=$(dirname "$script_path")
 
-echo "$script_path"
-echo "$script_dir"
-
 . "$script_dir/_config.sh"
 
 echo 'Configuring zsh...'

--- a/scripts/15_setup_starship.sh
+++ b/scripts/15_setup_starship.sh
@@ -4,9 +4,6 @@
 script_path=$(realpath "$0")
 script_dir=$(dirname "$script_path")
 
-echo "$script_path"
-echo "$script_dir"
-
 . "$script_dir/_config.sh"
 
 echo 'Configuring starship...'

--- a/scripts/50_setup_vscode.sh
+++ b/scripts/50_setup_vscode.sh
@@ -4,9 +4,6 @@
 script_path=$(realpath "$0")
 script_dir=$(dirname "$script_path")
 
-echo "$script_path"
-echo "$script_dir"
-
 . "$script_dir/_config.sh"
 
 if [ "$DOT_OS" = "darwin" ]; then


### PR DESCRIPTION
## Summary

- Delete unconditional `echo "$script_path"` / `echo "$script_dir"` debug lines that run on every `make install`
- Affected scripts: `scripts/10_setup_zsh.sh`, `scripts/15_setup_starship.sh`, `scripts/50_setup_vscode.sh`

## Test plan

- [ ] Run `make install` and confirm no spurious path output on stdout
- [ ] Run `make lint` — no new failures introduced (all failures in CI are pre-existing)

Closes #72

---
_Generated by [Claude Code](https://claude.ai/code/session_016uq1xSVagvGr6BCM4nVnNC)_