### PR TITLE
fix: address low-priority codebase review findings

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,7 +34,7 @@ DOT_VERBOSE=true ./scripts/10_setup_zsh.sh     # verbose/trace output
 ## Testing with Docker (Linux)
 
 ```sh
-./docker/build.sh    # builds ubuntu:24.04 image with required packages
+./docker/build.sh    # builds debian:12.13-slim image with required packages
 ./docker/run.sh      # mounts repo into container at ~/dotfiles
 # inside container:
 make install

--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -70,7 +70,7 @@ set -g @continuum-restore 'on'
 set -g @continuum-save-interval '10'
 
 # https://gist.github.com/ssh352/785395faad3163b2e0de32649f7ed45c
-set-option default-terminal "screen-256color"
+set-option -g default-terminal "screen-256color"
 
 #### ----> PLUGINS
 

--- a/files/vim/vimrc
+++ b/files/vim/vimrc
@@ -17,7 +17,6 @@ set ignorecase
 set smartcase
 set nowrap
 set paste
-filetype plugin indent on
 
 
 " Redraw on leaving insert mode

--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -74,8 +74,8 @@ else
 fi
 
 # functions
-for function in $ZSH_HOME/functions/*; do
-    source $function
+for fn in $ZSH_HOME/functions/*; do
+    source $fn
 done
 
 # aliases

--- a/scripts/10_setup_zsh.sh
+++ b/scripts/10_setup_zsh.sh
@@ -1,13 +1,7 @@
 #!/bin/sh -e
 [ -n "$DOT_VERBOSE" ] && set -x
 
-script_path=$(realpath "$0")
-script_dir=$(dirname "$script_path")
-
-echo "$script_path"
-echo "$script_dir"
-
-. "$script_dir/_config.sh"
+. "$(dirname "$0")/_config.sh"
 
 echo 'Configuring zsh...'
 if [ "$DOT_OS" = "linux" ]; then

--- a/scripts/15_setup_starship.sh
+++ b/scripts/15_setup_starship.sh
@@ -1,13 +1,7 @@
 #!/bin/sh -e
 [ -n "$DOT_VERBOSE" ] && set -x
 
-script_path=$(realpath "$0")
-script_dir=$(dirname "$script_path")
-
-echo "$script_path"
-echo "$script_dir"
-
-. "$script_dir/_config.sh"
+. "$(dirname "$0")/_config.sh"
 
 echo 'Configuring starship...'
 confirm_binaries "starship"

--- a/scripts/50_setup_vscode.sh
+++ b/scripts/50_setup_vscode.sh
@@ -1,13 +1,7 @@
 #!/bin/sh -e
 [ -n "$DOT_VERBOSE" ] && set -x
 
-script_path=$(realpath "$0")
-script_dir=$(dirname "$script_path")
-
-echo "$script_path"
-echo "$script_dir"
-
-. "$script_dir/_config.sh"
+. "$(dirname "$0")/_config.sh"
 
 if [ "$DOT_OS" = "darwin" ]; then
     vscode_user_dir="$HOME/Library/Application Support/Code/User"

--- a/scripts/_config.sh
+++ b/scripts/_config.sh
@@ -1,4 +1,4 @@
-#!/bin/zsh -ex
+#!/bin/sh
 
 [ -n "$DOT_VERBOSE" ] && set -x
 


### PR DESCRIPTION
## Summary
- Remove leftover debug `echo` lines and unused `script_path`/`script_dir` vars from `10_setup_zsh.sh`, `15_setup_starship.sh`, `50_setup_vscode.sh`
- Fix `_config.sh` shebang from `#!/bin/zsh -ex` to `#!/bin/sh` (file is always sourced, never executed)
- Rename loop variable `function` → `fn` in `zshrc` (reserved keyword)
- Remove duplicate `filetype plugin indent on` from `vimrc`
- Add `-g` flag to `set-option default-terminal` in `tmux.conf`
- Fix CLAUDE.md Docker image name (`ubuntu:24.04` → `debian:12.13-slim`)

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)