### PR TITLE
fix: remove set paste default in vimrc

### DIFF
--- a/files/vim/vimrc
+++ b/files/vim/vimrc
@@ -16,7 +16,6 @@ set cindent
 set ignorecase
 set smartcase
 set nowrap
-set paste
 
 
 " Redraw on leaving insert mode


### PR DESCRIPTION
## Summary
- Removes `set paste` from default vimrc — it permanently disables autoindent and other settings while active
- The existing `<Leader>p` toggle on line 68 covers the use case on demand

🤖 Generated with [Claude Code](https://claude.com/claude-code)