### PR TITLE
Guard starship eval in zshrc with command -v check

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -82,7 +82,7 @@ done
 source $ZSH_HOME/aliases
 
 # prompt
-eval "$(starship init zsh)"
+command -v starship &>/dev/null && eval "$(starship init zsh)"
 
 # git completion
 zstyle ':completion:*:*:git:*' script "$HOME/.zsh/git-completion.bash"


### PR DESCRIPTION
Every other tool-specific block in `zshrc` is already guarded with `command -v`; the starship `eval` at line 85 was the one exception. Without the guard, opening any interactive shell fails with `command not found: starship` on machines where starship hasn't been installed yet (e.g. a fresh clone before `make install`).

**Change:** wrap the eval in a `command -v starship &>/dev/null &&` guard, consistent with the pattern used for `aws`, `go`, `terraform`, etc.

Closes #73

---
_Generated by [Claude Code](https://claude.ai/code/session_01LbMybq1k5Fdk9DKUWRV5Y6)_