### PR TITLE
Fix tmux lint: prevent false failure when tpm is not installed

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -87,4 +87,4 @@ set -g @dracula-plugins "ssh-session"
 set -g @dracula-show-powerline true
 set -g @dracula-show-left-icon session
 
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.tmux/plugins/tpm/tpm || true'


### PR DESCRIPTION
## Summary

- `run '~/.tmux/plugins/tpm/tpm'` at the end of `files/tmux/tmux.conf` caused `make lint` to exit non-zero on fresh machines or CI where tpm is not yet installed, even though the config is otherwise valid.
- Fix: embed `|| true` inside the shell command string so tmux's `run` does not propagate a failure when the tpm binary is absent.

## Change

```diff
-run '~/.tmux/plugins/tpm/tpm'
+run '~/.tmux/plugins/tpm/tpm || true'
```

## Test plan

- [ ] Run `make lint` on a machine without tpm installed — `tmux: files/tmux/tmux.conf` check should now pass.
- [ ] Run `make lint` on a machine with tpm installed — behaviour unchanged, tpm loads normally.

Closes #79

---
_Generated by [Claude Code](https://claude.ai/code/session_01MdF6Ko8oLSYMJR4uQG8Yi2)_