### PR TITLE
Guard starship eval in zshrc with command -v check

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -82,7 +82,7 @@ done
 source $ZSH_HOME/aliases
 
 # prompt
-eval "$(starship init zsh)"
+command -v starship &>/dev/null && eval "$(starship init zsh)"
 
 # git completion
 zstyle ':completion:*:*:git:*' script "$HOME/.zsh/git-completion.bash"


### PR DESCRIPTION
## Summary

- `eval "$(starship init zsh)"` at `files/zsh/zshrc:85` had no `command -v starship` guard, unlike every other tool sourced in the file.
- On a machine where starship is not installed, opening any interactive shell would fail fatally.
- Fix: wrap with `command -v starship &>/dev/null && eval "$(starship init zsh)"`.

Closes #73

## Test plan

- [ ] Verify `make lint` passes (or produces no new failures vs. baseline)
- [ ] On a machine with starship installed: confirm prompt still loads normally
- [ ] On a machine without starship installed: confirm interactive shell opens without error

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mr5isgsDsT41WpC17Qtbj3)_