### PR TITLE
Fix fpath: use HOMEBREW_PREFIX for Apple Silicon compatibility

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -11,7 +11,7 @@ export ZSH=$HOME/.oh-my-zsh
 export KEYTIMEOUT=5
 ZSH_THEME=""
 plugins=(zsh-autosuggestions zsh-syntax-highlighting)
-fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions(/N) $fpath)
+fpath=($ZSH_HOME/completions ${HOMEBREW_PREFIX:-/usr/local}/share/zsh/site-functions(/N) $fpath)
 source $ZSH/oh-my-zsh.sh
 
 # zsh-autosuggest


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `/usr/local/share/zsh/site-functions` path in `fpath` with `${HOMEBREW_PREFIX:-/usr/local}/share/zsh/site-functions`
- On Apple Silicon Macs, Homebrew installs to `/opt/homebrew`; the old path meant completions installed there were silently ignored
- Falls back to `/usr/local` when `$HOMEBREW_PREFIX` is unset, preserving existing Intel Mac behaviour

## Test plan

- [ ] On Intel Mac: verify `fpath` still resolves to `/usr/local/share/zsh/site-functions`
- [ ] On Apple Silicon Mac: verify `fpath` resolves to `/opt/homebrew/share/zsh/site-functions`
- [ ] Run `make lint` — no regressions introduced

Closes #80

https://claude.ai/code/session_01VQJA3KZv9HxLXeV1kdCEro

---
_Generated by [Claude Code](https://claude.ai/code/session_01VQJA3KZv9HxLXeV1kdCEro)_