### PR TITLE
Guard oh-my-zsh source with directory existence check

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -12,7 +12,7 @@ export KEYTIMEOUT=5
 ZSH_THEME=""
 plugins=(zsh-autosuggestions zsh-syntax-highlighting)
 fpath=($ZSH_HOME/completions /usr/local/share/zsh/site-functions(/N) $fpath)
-source $ZSH/oh-my-zsh.sh
+[ -d "$ZSH" ] && source "$ZSH/oh-my-zsh.sh"
 
 # zsh-autosuggest
 ZSH_AUTOSUGGEST_USE_ASYNC="true"


### PR DESCRIPTION
## Summary

- `source $ZSH/oh-my-zsh.sh` at `files/zsh/zshrc:15` had no existence guard.
- On a fresh clone before `make install`, `$ZSH` (`~/.oh-my-zsh`) does not exist yet, so every interactive shell opened immediately fails fatally.
- Fix: wrap with `[ -d "$ZSH" ] && source "$ZSH/oh-my-zsh.sh"`, consistent with the defensive pattern already used throughout the file.

## Test plan

- [ ] On a machine with oh-my-zsh installed: verify interactive shell still loads normally
- [ ] On a fresh clone before `make install`: verify opening a shell no longer fails
- [ ] Run `make lint` — no new failures vs. baseline

Closes #74

---
_Generated by [Claude Code](https://claude.ai/code/session_01NSoLfcWx5hakwvNYxXgu5b)_