### PR TITLE
Fix FZF_CTRL_T_COMMAND: add PROJECTS_HOME fallback for non-login shells

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -50,9 +50,9 @@ if [ -f ~/.fzf.zsh ]; then
     source ~/.fzf.zsh
     export FZF_DEFAULT_OPTS='--height 40% --layout=reverse --border'
     if command -v fd &>/dev/null; then
-        export FZF_CTRL_T_COMMAND="fd -t d . $PROJECTS_HOME"
+        export FZF_CTRL_T_COMMAND="fd -t d . ${PROJECTS_HOME:-$HOME}"
     elif command -v fdfind &>/dev/null; then
-        export FZF_CTRL_T_COMMAND="fdfind -t d . $PROJECTS_HOME"
+        export FZF_CTRL_T_COMMAND="fdfind -t d . ${PROJECTS_HOME:-$HOME}"
     fi
 fi
 


### PR DESCRIPTION
## Summary

- `FZF_CTRL_T_COMMAND` embedded `$PROJECTS_HOME` which is only set in `zprofile` (login shells). In non-login interactive shells it expanded to empty, causing `fd`/`fdfind` to search the current directory instead of the projects root.
- Fixed by using `${PROJECTS_HOME:-$HOME}` as a fallback in both the `fd` and `fdfind` branches.

Closes #78

## Test plan

- [ ] Open a non-login interactive zsh shell (e.g. a terminal emulator that doesn't source `zprofile`)
- [ ] Confirm `$PROJECTS_HOME` is unset in that shell
- [ ] Press `Ctrl+T` and verify fzf searches `$HOME` rather than the current directory
- [ ] In a login shell where `$PROJECTS_HOME` is set, confirm `Ctrl+T` still searches the projects root

---
_Generated by [Claude Code](https://claude.ai/code/session_013NRwNVZSxhLaHbBqxhWQ2E)_