### PR TITLE
Fix 20_setup_tmux.sh: only run install_plugins when tpm is installed/updated

### DIFF
--- a/scripts/20_setup_tmux.sh
+++ b/scripts/20_setup_tmux.sh
@@ -19,8 +19,7 @@ if [ -n "$DOT_FORCE" ] || [ ! -d "$HOME/.tmux/plugins/tpm" ]; then
     echo "Installing tmux plugins..."
     rm -rf "$HOME/.tmux/plugins/tpm"
     git clone --depth 1 https://github.com/tmux-plugins/tpm "$HOME/.tmux/plugins/tpm"
+    "$HOME/.tmux/plugins/tpm/bin/install_plugins"
 fi
-
-"$HOME/.tmux/plugins/tpm/bin/install_plugins"
 
 echo "-> tmux setup finished."


### PR DESCRIPTION
## Summary

- `install_plugins` was called unconditionally on every `make install`, making repeat runs slow
- Moves the call inside the `DOT_FORCE`/tpm-missing guard so it only runs when tpm is freshly cloned or a force-reinstall is requested

## Test plan

- [ ] Run `make install` twice back-to-back — second run should skip plugin installation
- [ ] Run `DOT_FORCE=true make install` — should clone tpm and run `install_plugins`
- [ ] Run `make install` after deleting `~/.tmux/plugins/tpm` — should clone tpm and run `install_plugins`

Closes #81

---
_Generated by [Claude Code](https://claude.ai/code/session_016V6FuRzG1bnPwLn54vxu1z)_