### PR TITLE
Fix Docker image: replace hardcoded username 'jan' with build-arg

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,9 @@
 FROM debian:12.13-slim
 ENV DEBIAN_FRONTEND=noninteractive
 
+ARG USERNAME=jan
+ENV HOME=/home/${USERNAME}
+
 # Locales
 ENV LANG="en_US.UTF-8" LC_ALL="en_US.UTF-8" LANGUAGE="en_US.UTF-8"
 RUN apt-get update && apt-get install -y \
@@ -32,19 +35,19 @@ RUN mkdir -p /etc/apt/keyrings \
 RUN sh -c "$(curl -fsSL https://starship.rs/install.sh)" -- --yes
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-RUN useradd --create-home --shell /bin/zsh jan && echo "jan:docker" | chpasswd && adduser jan sudo
-USER jan:jan
-WORKDIR /home/jan
+RUN useradd --create-home --shell /bin/zsh "${USERNAME}" && echo "${USERNAME}:docker" | chpasswd && adduser "${USERNAME}" sudo
+USER ${USERNAME}:${USERNAME}
+WORKDIR ${HOME}
 
-RUN wget -P /home/jan/.local/share/fonts https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/FiraCode.zip \
-    && cd /home/jan/.local/share/fonts \
+RUN wget -P "${HOME}/.local/share/fonts" https://github.com/ryanoasis/nerd-fonts/releases/download/v3.2.1/FiraCode.zip \
+    && cd "${HOME}/.local/share/fonts" \
     && unzip FiraCode.zip \
     && rm FiraCode.zip \
     && fc-cache -fv
 
 RUN mkdir -p ~/.local/bin \
-    && ln -s $(which fdfind) ~/.local/bin/fd
+    && ln -s "$(which fdfind)" ~/.local/bin/fd
 
-RUN touch /home/jan/.zshrc
+RUN touch "${HOME}/.zshrc"
 
 CMD [ "/bin/zsh" ]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -2,4 +2,5 @@
 
 cd "$(dirname "$0")"
 docker buildx build . \
+    --build-arg "USERNAME=$(id -un)" \
     --tag dotfiles:latest

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,11 +1,12 @@
 #!/bin/bash -eux
 
+USERNAME="$(id -un)"
 docker run \
     --rm \
     --interactive \
     --tty \
-    --volume "$(pwd):/home/jan/dotfiles" \
+    --volume "$(pwd):/home/${USERNAME}/dotfiles" \
     --hostname dotfiles-test \
     --env DOT_VERBOSE="true" \
-    --workdir /home/jan/dotfiles \
+    --workdir "/home/${USERNAME}/dotfiles" \
     dotfiles:latest


### PR DESCRIPTION
## Summary

- Replace hardcoded `jan` / `/home/jan` in `docker/Dockerfile` and `docker/run.sh` so anyone can use the Docker testing workflow without editing files
- `Dockerfile` gains `ARG USERNAME=jan` (default preserved) and `ENV HOME=/home/${USERNAME}`; all `jan`-specific paths now reference `${USERNAME}` / `${HOME}`
- `build.sh` passes `--build-arg "USERNAME=$(id -un)"` so the image is built with the host caller's username
- `run.sh` derives the container home path from `$(id -un)` at runtime to match the built image

## Test plan

- [ ] `make docker-build` builds the image without errors (username matches current host user)
- [ ] `make docker-run` mounts the repo into the correct path inside the container
- [ ] `make install` runs successfully inside the container
- [ ] Original default (`jan`) still works when `USERNAME` build-arg is not provided

Closes #82

---
_Generated by [Claude Code](https://claude.ai/code/session_01DEkLUcAtsFy8drJk9AEP4i)_