### PR TITLE
Add ghostty configuration to dotfiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ My dotfiles for macOS and Linux.
 - **vim** — editor
 - **git** — global config
 - **vscode** — editor settings
-- **ghostty** — terminal emulator
+- **ghostty** — terminal emulator config
 
 ## Setup
 
@@ -32,7 +32,7 @@ Or run individual scripts:
 ./scripts/30_setup_vim.sh
 ./scripts/40_setup_git.sh
 ./scripts/50_setup_vscode.sh
-./scripts/55_setup_ghostty.sh
+./scripts/60_setup_ghostty.sh
 ```
 
 ## Linting

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ My dotfiles for macOS and Linux.
 - **vim** — editor
 - **git** — global config
 - **vscode** — editor settings
+- **ghostty** — terminal emulator
 
 ## Setup
 
@@ -31,6 +32,7 @@ Or run individual scripts:
 ./scripts/30_setup_vim.sh
 ./scripts/40_setup_git.sh
 ./scripts/50_setup_vscode.sh
+./scripts/55_setup_ghostty.sh
 ```
 
 ## Linting

--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,0 +1,1 @@
+confirm-close-surface = false

--- a/scripts/55_setup_ghostty.sh
+++ b/scripts/55_setup_ghostty.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+[ -n "$DOT_VERBOSE" ] && set -x
+
+. "$(dirname "$0")/_config.sh"
+
+echo 'Configuring ghostty...'
+confirm_binaries "ghostty"
+
+mkdir -p "$HOME/.config/ghostty"
+cp -f "$DOT_ROOT/files/ghostty/config" "$HOME/.config/ghostty/config"
+
+echo 'Done configuring ghostty.'

--- a/scripts/60_setup_ghostty.sh
+++ b/scripts/60_setup_ghostty.sh
@@ -1,0 +1,12 @@
+#!/bin/sh -e
+[ -n "$DOT_VERBOSE" ] && set -x
+
+. "$(dirname "$0")/_config.sh"
+
+echo 'Configuring ghostty...'
+confirm_binaries "ghostty"
+
+mkdir -p "$HOME/.config/ghostty"
+cp -f "$DOT_ROOT/files/ghostty/config" "$HOME/.config/ghostty/config"
+
+echo 'Done configuring ghostty.'


### PR DESCRIPTION
## Summary

- Adds `files/ghostty/config` with `confirm-close-surface = false`
- Adds `scripts/55_setup_ghostty.sh` to copy the config to `~/.config/ghostty/config`, guarded by `confirm_binaries "ghostty"`
- Updates `README.md` to list ghostty under configured tools and individual scripts

## Test plan

- [ ] Run `./scripts/55_setup_ghostty.sh` on a machine with ghostty installed and verify `~/.config/ghostty/config` is created with the correct content
- [ ] Run `make install` and confirm the ghostty step appears in the results summary
- [ ] On a machine without ghostty, confirm the step fails gracefully with a missing-binary message

Closes #88

---
_Generated by [Claude Code](https://claude.ai/code/session_01EHRYqYPH1B1KVxALY84x5W)_