### PR TITLE
Add ghostty terminal emulator configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Shared config sourced by all setup scripts. Sets `$DOT_OS` (`darwin`/`linux`/`wi
 - `zsh/` — `zshenv` (all shells), `zprofile` (login), `zshrc` (interactive). Tool-specific env vars are guarded with `command -v <tool>` checks.
 - `shell/aliases` and `shell/functions/` — sourced by `zshrc`; functions are auto-loaded from `~/.zsh/functions/`
 - `zsh/completions/` — custom completions copied to `~/.zsh/completions/`
-- Other dirs (`git/`, `tmux/`, `vim/`, `starship/`, `vscode/`) each have a corresponding `scripts/NN_setup_*.sh`
+- Other dirs (`git/`, `tmux/`, `vim/`, `starship/`, `vscode/`, `ghostty/`) each have a corresponding `scripts/NN_setup_*.sh`
 
 ### Platform differences
 - Linux uses `fdfind` (the Ubuntu package name); macOS uses `fd`

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ My dotfiles for macOS and Linux.
 - **vim** — editor
 - **git** — global config
 - **vscode** — editor settings
+- **ghostty** — terminal emulator config
 
 ## Setup
 
@@ -31,6 +32,7 @@ Or run individual scripts:
 ./scripts/30_setup_vim.sh
 ./scripts/40_setup_git.sh
 ./scripts/50_setup_vscode.sh
+./scripts/60_setup_ghostty.sh
 ```
 
 ## Linting

--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,0 +1,1 @@
+confirm-close-surface = false

--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,1 +1,11 @@
 confirm-close-surface = false
+mouse-hide-while-typing = true
+font-family = FiraCode Nerd Font Mono
+font-thicken = true
+window-padding-x = 8
+window-padding-y = 4
+macos-titlebar-style = hidden
+background-opacity = 0.95
+background-blur-radius = 20
+term = xterm-256color
+theme = JetBrains Darcula

--- a/files/help/ghostty
+++ b/files/help/ghostty
@@ -5,6 +5,7 @@
 | Action              | How                                          |
 |---------------------|----------------------------------------------|
 | Reload config       | `Cmd+Shift+,` or Ghostty → Reload Configuration |
+| Close window        | `Cmd+W`                                      |
 
 Config file: `~/.config/ghostty/config`
 

--- a/files/help/ghostty
+++ b/files/help/ghostty
@@ -1,0 +1,12 @@
+# ghostty
+
+## Configuration
+
+| Action              | How                                          |
+|---------------------|----------------------------------------------|
+| Reload config       | `Cmd+Shift+,` or Ghostty → Reload Configuration |
+
+Config file: `~/.config/ghostty/config`
+
+Most settings apply immediately on reload. Some (e.g. `term`) only take
+effect for new windows.

--- a/scripts/60_setup_ghostty.sh
+++ b/scripts/60_setup_ghostty.sh
@@ -1,0 +1,16 @@
+#!/bin/sh -e
+[ -n "$DOT_VERBOSE" ] && set -x
+
+. "$(dirname "$0")/_config.sh"
+
+if ! command -v ghostty >/dev/null 2>&1; then
+    echo 'ghostty not found, skipping ghostty setup.'
+    exit 0
+fi
+
+echo 'Configuring ghostty...'
+
+mkdir -p "$HOME/.config/ghostty"
+cp -f "$DOT_ROOT/files/ghostty/config" "$HOME/.config/ghostty/config"
+
+echo 'Done configuring ghostty.'


### PR DESCRIPTION
## Summary

- Adds `files/ghostty/config` with `confirm-close-surface = false`
- Adds `scripts/60_setup_ghostty.sh` to copy the config to `~/.config/ghostty/config`
- Script is guarded with `command -v ghostty` so it silently skips if ghostty is not installed
- Updates `README.md` to list ghostty under configured tools and individual scripts

## Test plan

- [ ] Run `./scripts/60_setup_ghostty.sh` on a machine with ghostty installed — verify `~/.config/ghostty/config` is created with the correct content
- [ ] Run `./scripts/60_setup_ghostty.sh` on a machine without ghostty — verify it exits cleanly with a skip message
- [ ] Run `make install` and confirm ghostty setup runs as part of the full install

Closes #88

---
_Generated by [Claude Code](https://claude.ai/code/session_015i7aRJgi4VjFnLTnuspU63)_