### PR TITLE
Fix tmux kill-server firing when server has no sessions

### DIFF
--- a/scripts/20_setup_tmux.sh
+++ b/scripts/20_setup_tmux.sh
@@ -8,7 +8,7 @@ confirm_binaries "git" "tmux"
 
 cp -f "${DOT_ROOT}/files/tmux/tmux.conf" "$HOME/.tmux.conf"
 
-if tmux list-sessions >/dev/null 2>&1; then
+if tmux info >/dev/null 2>&1; then
     echo "tmux server is running — reload config with prefix+r or 'tmux source-file ~/.tmux.conf'" >>"$HOME/.dotfiles-notes"
 else
     tmux kill-server || true


### PR DESCRIPTION
## Summary

`tmux list-sessions` exits non-zero both when no tmux server is running **and** when a server is running but has no sessions. This caused `tmux kill-server` to fire unexpectedly in the second case — silently killing a running server during setup.

## Fix

Replace `tmux list-sessions` with `tmux info`, which exits non-zero only when no server process exists at all, regardless of session count.

```diff
-if tmux list-sessions >/dev/null 2>&1; then
+if tmux info >/dev/null 2>&1; then
```

## Behaviour after fix

| State | `list-sessions` | `tmux info` | Action taken |
|---|---|---|---|
| No server | exit 1 | exit 1 | `kill-server` (no-op, safe) |
| Server running, no sessions | exit 1 ❌ | exit 0 ✅ | print reload note |
| Server running, with sessions | exit 0 | exit 0 | print reload note |

Closes #52

---
_Generated by [Claude Code](https://claude.ai/code/session_016bNYdUt45n73KhCRWwWbVA)_