### PR TITLE
tmux: replace Dracula theme with custom Nord-style status bar at bottom

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -48,8 +48,8 @@ bind -n C-l send-keys C-l \; run-shell "sleep .3s" \; clear-history
 # set default shell to zsh
 set -g default-shell /bin/zsh
 
-# # Status position top
-set -g status-position top
+# Status position
+set -g status-position bottom
 
 # mouse support and clipboard -> https://stackoverflow.com/a/53545001/512155
 set -g mouse on
@@ -72,19 +72,35 @@ set -g @continuum-save-interval '10'
 # https://gist.github.com/ssh352/785395faad3163b2e0de32649f7ed45c
 set-option -g default-terminal "screen-256color"
 
+#### ----> STATUS BAR STYLE
+
+# Nord-inspired color palette
+gray_light="#D8DEE9"
+gray_medium="#ABB2BF"
+gray_dark="#3B4252"
+green_soft="#A3BE8C"
+blue_muted="#81A1C1"
+cyan_soft="#88C0D0"
+
+set -g status-interval 3
+set -g status-left-length 100
+set -g status-style "fg=${gray_light},bg=default"
+set -g status-left "#[fg=${green_soft},bold] #S #[fg=${gray_light},nobold] | "
+set -g status-right " #{cpu}  #{mem} "
+set -g window-status-current-format "#[fg=${cyan_soft},bold]  #[underscore]#I:#W#[nounderscore]#{?window_zoomed_flag, 󰍋 ,}"
+set -g window-status-format " #I:#W"
+set -g message-style "fg=${gray_light},bg=default"
+set -g mode-style "fg=${gray_dark},bg=${blue_muted}"
+set -g pane-border-style "fg=${gray_dark}"
+set -g pane-active-border-style "fg=${green_soft}"
+
 #### ----> PLUGINS
 
 # List of plugins
-set -g @plugin 'dracula/tmux'
 set -g @plugin 'tmux-plugins/tpm'
 set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
-
-# https://draculatheme.com/tmux
-# Plugin config must come before tpm's run command
-set -g @dracula-plugins "ssh-session"
-set -g @dracula-show-powerline true
-set -g @dracula-show-left-icon session
+set -g @plugin 'hendrikmi/tmux-cpu-mem-monitor'
 
 run '~/.tmux/plugins/tpm/tpm || true'


### PR DESCRIPTION
## Summary

Implements the tmux status line update requested in #99.

**Differences from the [reference config](https://github.com/hendrikmi/dotfiles/blob/4e3f607241bd2f079bff15f76ef95f73df8b474f/tmux/tmux.conf):**

- **Position:** Reference uses `bottom` (with a `top` override in the style section); current repo used `top`. This PR moves to `bottom` as preferred.
- **Theme engine:** Reference uses a custom hand-rolled Nord palette instead of the `dracula/tmux` plugin. This PR replaces Dracula with the same approach.
- **Status left:** Session name in soft green, separated by `|`.
- **Status right:** CPU and memory via `hendrikmi/tmux-cpu-mem-monitor` (updated every 3 s), replacing the Dracula `ssh-session` widget.
- **Window status:** Active window highlighted in cyan with underline and a zoom indicator; inactive windows shown as plain `#I:#W`.
- **Pane borders:** Styled with Nord grays/green instead of Dracula defaults.

## Changes

- `files/tmux/tmux.conf` — moves status bar to bottom, removes `dracula/tmux` plugin and its config, adds Nord-inspired color variables, custom status-left/right/window formats, and the `hendrikmi/tmux-cpu-mem-monitor` plugin.

Closes #99

---
_Generated by [Claude Code](https://claude.ai/code/session_012Uu27tEHxaW2GYojWQPPPQ)_