### PR TITLE
Fail fast in lint.sh when required tools are missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Check syntax of all config and shell files:
 make lint
 ```
 
+Requires `zsh`, `shfmt`, `shellcheck`, and `python3` (≥ 3.11); lint fails fast with a list of missing tools instead of reporting per-file failures.
+
 ## Testing with Docker
 
 Build and run a Linux container to test the setup:

--- a/tests/lint.sh
+++ b/tests/lint.sh
@@ -5,6 +5,20 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 PASS=0
 FAIL=0
 
+# Fail fast if lint tools are missing — a missing binary would otherwise
+# surface as per-file FAILs indistinguishable from real lint problems.
+MISSING=()
+for tool in zsh shfmt shellcheck python3; do
+    command -v "$tool" &>/dev/null || MISSING+=("$tool")
+done
+if command -v python3 &>/dev/null && ! python3 -c 'import tomllib' &>/dev/null; then
+    MISSING+=("python3-tomllib (python >= 3.11)")
+fi
+if [ "${#MISSING[@]}" -gt 0 ]; then
+    echo "lint: missing required tools: ${MISSING[*]} — install them and re-run" >&2
+    exit 1
+fi
+
 check() {
     local label="$1"
     shift


### PR DESCRIPTION
## Why

The nightly cloud routine reported 34 lint failures while a local run passes clean. The failures were phantom: `check()` in `tests/lint.sh` counts a check as FAIL when the tool binary itself (`zsh`, `shfmt`, `shellcheck`) isn't installed, which is indistinguishable from real lint problems.

## What

- `tests/lint.sh`: preflight check for `zsh`, `shfmt`, `shellcheck`, `python3` (with `tomllib`, i.e. ≥ 3.11). If anything is missing, exit 1 with a single error listing the missing tools instead of dozens of per-file FAILs. The existing soft tmux guard is unchanged.
- `README.md`: document the lint tool requirements and fail-fast behavior.

The nightly routine was updated separately to apt-install these tools in its sandbox before running `make lint`, so cloud runs now lint with full coverage.

## Verification

- `make lint` locally: 47 passed, 0 failed — unchanged behavior when all tools are present
- `PATH=/usr/bin:/bin bash tests/lint.sh`: prints `lint: missing required tools: shfmt shellcheck python3-tomllib (python >= 3.11) — install them and re-run`, exit 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)