### PR TITLE
feat: expand starship config with Nord theme and update prompt symbols

### DIFF
--- a/files/starship/starship.toml
+++ b/files/starship/starship.toml
@@ -1,11 +1,53 @@
 add_newline = true
+palette = "nord"
+
+[aws]
+style = 'yellow'
+format = '[$symbol($profile )(\[$duration\] )]($style)'
 
 [character]
-success_symbol = '[](bold green) '
-error_symbol = '[](bold red) '
+success_symbol = '[➤](bold green) '
+error_symbol = '[✖](bold red) '
+
+[docker_context]
+style = 'fg:#06969A'
+format = '[$symbol]($style) $path'
+detect_files = ['docker-compose.yml', 'docker-compose.yaml', 'Dockerfile']
+detect_extensions = ['Dockerfile']
+
+[git_branch]
+style = 'fg:green'
+symbol = ' '
+format = '[on](white) [$symbol$branch ]($style)'
+
+[git_status]
+style = 'fg:red'
+format = '([$all_status$ahead_behind]($style) )'
+
+[fill]
+symbol = ' '
 
 [kubernetes]
 disabled = false
+style = 'teal'
+
+[package]
+disabled = false
+style = 'teal'
 
 [python]
 python_binary = [["uv", "run", "--no-python-downloads", "python"]]
+style = 'teal'
+
+[palettes.nord]
+dark_blue = '#5E81AC'
+blue = '#81A1C1'
+teal = '#88C0D0'
+red = '#BF616A'
+orange = '#D08770'
+green = '#A3BE8C'
+yellow = '#EBCB8B'
+purple = '#B48EAD'
+gray = '#434C5E'
+black = '#2E3440'
+white='#D8DEE9'


### PR DESCRIPTION
## Summary
- Added Nord color palette definition to `starship.toml`
- Configured AWS, docker, git branch/status, kubernetes, package, and python modules with Nord-themed styles
- Updated prompt symbols (`➤` for success, `✖` for error)
- Set `python_binary` to use `uv run` for Python execution

## Test plan
- [ ] Verify starship prompt renders correctly with Nord theme colors
- [ ] Confirm prompt symbols display as expected on success/error
- [ ] Check AWS, git, kubernetes, and python module formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)