### PR TITLE
feat(nvim): split config into modules, add yaml formatting, git blame

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ My dotfiles for macOS and Linux.
 - **starship** — shell prompt
 - **tmux** — terminal multiplexer
 - **vim** — editor
-- **neovim** — editor (lazy.nvim plugin manager, dracula theme, nvim-tree, lualine, nvim-surround)
+- **neovim** — editor (lazy.nvim plugin manager, nord theme, telescope, nvim-tree, mason/LSP, conform formatting)
 - **git** — global config
 - **vscode** — editor settings
 - **ghostty** — terminal emulator config

--- a/files/ghostty/config
+++ b/files/ghostty/config
@@ -1,5 +1,5 @@
 background-blur-radius = 20
-background-opacity = 0.95
+background-opacity = 0.85
 confirm-close-surface = false
 font-family = FiraCode Nerd Font Mono
 font-thicken = true

--- a/files/help/neovim
+++ b/files/help/neovim
@@ -17,7 +17,9 @@ Leader key is `Space`.
 | Key          | Action                        |
 |--------------|-------------------------------|
 | `Space+ff`   | Find files by name            |
+| `Space+fF`   | Find files by name, including gitignored |
 | `Space+fg`   | Live grep (search file contents) |
+| `Space+fG`   | Live grep, including gitignored content |
 | `Space+fb`   | Browse open buffers           |
 
 Inside Telescope: type to filter, `↑/↓` or `Ctrl+k/j` to move, `Enter` to open, `Ctrl+v` for vertical split, `Ctrl+x` for horizontal split.
@@ -35,6 +37,10 @@ Note: live grep requires `ripgrep` (`brew install ripgrep`).
 | `a`     | Create new file               |
 | `d`     | Delete file                   |
 | `r`     | Rename file                   |
+| `y`     | Copy filename                  |
+| `Y`     | Copy relative path             |
+| `gy`    | Copy absolute path             |
+| `I`     | Toggle visibility of gitignored files (shown by default) |
 
 ## Splits & pane navigation
 
@@ -43,6 +49,7 @@ Note: live grep requires `ripgrep` (`brew install ripgrep`).
 | `:vs`          | Vertical split                              |
 | `:sp`          | Horizontal split                            |
 | `Ctrl+h/j/k/l` | Move between splits and tmux panes          |
+| `Ctrl+w` then `<`/`>` | Shrink / widen the focused split     |
 
 ## LSP
 

--- a/files/nvim/init.lua
+++ b/files/nvim/init.lua
@@ -15,109 +15,14 @@ vim.opt.rtp:prepend(lazypath)
 -- Leader key must be set before plugins load
 vim.g.mapleader = " "
 
--- Plugins
-require("lazy").setup({
-    { "shaunsingh/nord.nvim" }, -- nord color scheme
-    {
-        "nvim-tree/nvim-tree.lua", -- file explorer sidebar
-        dependencies = { "nvim-tree/nvim-web-devicons" },
-        opts = {},
-    },
-    {
-        "nvim-lualine/lualine.nvim", -- configurable status line
-        dependencies = { "nvim-tree/nvim-web-devicons" },
-        opts = { options = { theme = "nord" } },
-    },
-    { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
-    { "lewis6991/gitsigns.nvim", opts = {} }, -- git diff indicators in the sign column, hunk navigation and staging
-    {
-        "nvim-telescope/telescope.nvim", -- fuzzy finder for files, grep, buffers, git history
-        dependencies = { "nvim-lua/plenary.nvim" },
-        opts = {},
-    },
-    {
-        "nvim-treesitter/nvim-treesitter", -- smarter syntax highlighting based on parse trees
-        build = ":TSUpdate",
-        opts = { highlight = { enable = true }, indent = { enable = true }, ensure_installed = { "python", "yaml" } },
-    },
-    { "williamboman/mason.nvim", opts = {} }, -- installs and manages language servers
-    {
-        "williamboman/mason-lspconfig.nvim", -- bridges mason and nvim-lspconfig; auto-installs and configures LSPs
-        dependencies = { "neovim/nvim-lspconfig" },
-        config = function()
-            require("mason-lspconfig").setup({
-                ensure_installed = { "pyright", "ruff", "yamlls" },
-                handlers = {
-                    function(server_name)
-                        require("lspconfig")[server_name].setup({})
-                    end,
-                    ["yamlls"] = function()
-                        require("lspconfig").yamlls.setup({
-                            settings = {
-                                yaml = {
-                                    schemaStore = { enable = false, url = "" },
-                                    schemas = require("schemastore").yaml.schemas(),
-                                },
-                            },
-                        })
-                    end,
-                },
-            })
-        end,
-    },
-    {
-        "hrsh7th/nvim-cmp", -- autocompletion menu
-        dependencies = {
-            "hrsh7th/cmp-nvim-lsp", -- LSP completions
-            "hrsh7th/cmp-buffer",   -- buffer word completions
-            "hrsh7th/cmp-path",     -- file path completions
-        },
-    },
-    { "b0o/SchemaStore.nvim" }, -- provides 500+ JSON/YAML schemas (Kubernetes, Helm, GitHub Actions, etc.)
-    { "numToStr/Comment.nvim", opts = {} }, -- toggle comments with gcc (line) or gc (visual)
-    { "folke/which-key.nvim", opts = {} },  -- shows available keymaps when pausing mid-sequence
-    { "christoomey/vim-tmux-navigator" },   -- seamless navigation between neovim splits and tmux panes
-})
+-- Plugins (collected from lua/*.lua modules)
+local plugins = {}
+for _, mod in ipairs({ "ui", "navigation", "editor", "treesitter", "lsp", "format" }) do
+    vim.list_extend(plugins, require(mod))
+end
+require("lazy").setup(plugins)
 
 vim.cmd.colorscheme("nord")
 
--- Editor settings (mirrors vimrc)
-local opt = vim.opt
-opt.clipboard = "unnamedplus"
-opt.cursorline = true
-opt.expandtab = true
-opt.ignorecase = true
-opt.joinspaces = false
-opt.laststatus = 3
-opt.number = true
-opt.relativenumber = true
-opt.scrolloff = 8
-opt.shiftwidth = 2
-opt.signcolumn = "yes"
-opt.smartcase = true
-opt.tabstop = 2
-opt.termguicolors = true
-opt.undofile = true
-opt.wrap = false
-
--- Keymaps
-local map = vim.keymap.set
-map("n", "n", "nzz")
-map("n", "N", "Nzz")
-map("n", "*", "*zz")
-map("n", "#", "#zz")
-map("n", "g*", "g*zz")
-map("n", "g#", "g#zz")
-map("n", "<Leader>h", ":set hls!<CR>")
-map("n", "<Leader>i", ":set ignorecase!<CR>")
-map("n", "<Leader>p", ":set paste!<CR>")
-map("n", "<Leader>c", ":set cursorline!<CR>")
-map("n", "<Leader>e", ":NvimTreeToggle<CR>")
-map("n", "<Leader>ff", "<cmd>Telescope find_files<CR>")
-map("n", "<Leader>fg", "<cmd>Telescope live_grep<CR>")
-map("n", "<Leader>fb", "<cmd>Telescope buffers<CR>")
--- vim-tmux-navigator: navigate splits/panes from any mode
-map({ "n", "i", "v" }, "<C-h>", "<cmd>TmuxNavigateLeft<CR>")
-map({ "n", "i", "v" }, "<C-j>", "<cmd>TmuxNavigateDown<CR>")
-map({ "n", "i", "v" }, "<C-k>", "<cmd>TmuxNavigateUp<CR>")
-map({ "n", "i", "v" }, "<C-l>", "<cmd>TmuxNavigateRight<CR>")
+-- Core editor settings and keymaps
+require("options")

--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -1,0 +1,8 @@
+return {
+    { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
+    {
+        "lewis6991/gitsigns.nvim", -- git diff indicators in the sign column, hunk navigation and staging
+        opts = { current_line_blame = true },
+    },
+    { "numToStr/Comment.nvim", opts = {} }, -- toggle comments with gcc (line) or gc (visual)
+}

--- a/files/nvim/lua/format.lua
+++ b/files/nvim/lua/format.lua
@@ -1,0 +1,14 @@
+return {
+    {
+        "WhoIsSethDaniel/mason-tool-installer.nvim", -- ensures non-LSP tools (formatters, linters) are installed via mason
+        dependencies = { "williamboman/mason.nvim" },
+        opts = { ensure_installed = { "yamlfmt" } },
+    },
+    {
+        "stevearc/conform.nvim", -- formats buffers on save using per-filetype formatters
+        opts = {
+            formatters_by_ft = { yaml = { "yamlfmt" } },
+            format_on_save = { timeout_ms = 500, lsp_fallback = true },
+        },
+    },
+}

--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -1,0 +1,36 @@
+return {
+    { "williamboman/mason.nvim", opts = {} }, -- installs and manages language servers
+    {
+        "williamboman/mason-lspconfig.nvim", -- bridges mason and nvim-lspconfig; auto-installs and configures LSPs
+        dependencies = { "neovim/nvim-lspconfig" },
+        config = function()
+            require("mason-lspconfig").setup({
+                ensure_installed = { "pyright", "ruff", "yamlls" },
+                handlers = {
+                    function(server_name)
+                        require("lspconfig")[server_name].setup({})
+                    end,
+                    ["yamlls"] = function()
+                        require("lspconfig").yamlls.setup({
+                            settings = {
+                                yaml = {
+                                    schemaStore = { enable = false, url = "" },
+                                    schemas = require("schemastore").yaml.schemas(),
+                                },
+                            },
+                        })
+                    end,
+                },
+            })
+        end,
+    },
+    {
+        "hrsh7th/nvim-cmp", -- autocompletion menu
+        dependencies = {
+            "hrsh7th/cmp-nvim-lsp", -- LSP completions
+            "hrsh7th/cmp-buffer",   -- buffer word completions
+            "hrsh7th/cmp-path",     -- file path completions
+        },
+    },
+    { "b0o/SchemaStore.nvim" }, -- provides 500+ JSON/YAML schemas (Kubernetes, Helm, GitHub Actions, etc.)
+}

--- a/files/nvim/lua/navigation.lua
+++ b/files/nvim/lua/navigation.lua
@@ -1,0 +1,27 @@
+local map = vim.keymap.set
+
+map("n", "<Leader>e", ":NvimTreeToggle<CR>")
+map("n", "<Leader>ff", "<cmd>Telescope find_files<CR>")
+map("n", "<Leader>fF", function() require("telescope.builtin").find_files({ no_ignore = true }) end)
+map("n", "<Leader>fg", "<cmd>Telescope live_grep<CR>")
+map("n", "<Leader>fG", function() require("telescope.builtin").live_grep({ additional_args = { "--no-ignore" } }) end)
+map("n", "<Leader>fb", "<cmd>Telescope buffers<CR>")
+-- vim-tmux-navigator: navigate splits/panes from any mode
+map({ "n", "i", "v" }, "<C-h>", "<cmd>TmuxNavigateLeft<CR>")
+map({ "n", "i", "v" }, "<C-j>", "<cmd>TmuxNavigateDown<CR>")
+map({ "n", "i", "v" }, "<C-k>", "<cmd>TmuxNavigateUp<CR>")
+map({ "n", "i", "v" }, "<C-l>", "<cmd>TmuxNavigateRight<CR>")
+
+return {
+    {
+        "nvim-tree/nvim-tree.lua", -- file explorer sidebar
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        opts = { filters = { git_ignored = false }, update_focused_file = { enable = true } },
+    },
+    {
+        "nvim-telescope/telescope.nvim", -- fuzzy finder for files, grep, buffers, git history
+        dependencies = { "nvim-lua/plenary.nvim" },
+        opts = {},
+    },
+    { "christoomey/vim-tmux-navigator" }, -- seamless navigation between neovim splits and tmux panes
+}

--- a/files/nvim/lua/options.lua
+++ b/files/nvim/lua/options.lua
@@ -1,0 +1,31 @@
+-- Editor settings (mirrors vimrc)
+local opt = vim.opt
+opt.clipboard = "unnamedplus"
+opt.cursorline = true
+opt.expandtab = true
+opt.ignorecase = true
+opt.joinspaces = false
+opt.laststatus = 3
+opt.number = true
+opt.relativenumber = true
+opt.scrolloff = 16
+opt.shiftwidth = 2
+opt.signcolumn = "yes"
+opt.smartcase = true
+opt.tabstop = 2
+opt.termguicolors = true
+opt.undofile = true
+opt.wrap = false
+
+-- Keymaps
+local map = vim.keymap.set
+map("n", "n", "nzz")
+map("n", "N", "Nzz")
+map("n", "*", "*zz")
+map("n", "#", "#zz")
+map("n", "g*", "g*zz")
+map("n", "g#", "g#zz")
+map("n", "<Leader>h", ":set hls!<CR>")
+map("n", "<Leader>i", ":set ignorecase!<CR>")
+map("n", "<Leader>p", ":set paste!<CR>")
+map("n", "<Leader>c", ":set cursorline!<CR>")

--- a/files/nvim/lua/treesitter.lua
+++ b/files/nvim/lua/treesitter.lua
@@ -1,0 +1,7 @@
+return {
+    {
+        "nvim-treesitter/nvim-treesitter", -- smarter syntax highlighting based on parse trees
+        build = ":TSUpdate",
+        opts = { highlight = { enable = true }, indent = { enable = true }, ensure_installed = { "python", "yaml" } },
+    },
+}

--- a/files/nvim/lua/ui.lua
+++ b/files/nvim/lua/ui.lua
@@ -1,0 +1,12 @@
+-- must be set before the colorscheme is applied (see init.lua)
+vim.g.nord_disable_background = true
+
+return {
+    { "shaunsingh/nord.nvim" }, -- nord color scheme
+    {
+        "nvim-lualine/lualine.nvim", -- configurable status line
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        opts = { options = { theme = "nord" } },
+    },
+    { "folke/which-key.nvim", opts = {} }, -- shows available keymaps when pausing mid-sequence
+}

--- a/scripts/35_setup_nvim.sh
+++ b/scripts/35_setup_nvim.sh
@@ -6,7 +6,8 @@
 echo 'Configuring neovim...'
 confirm_binaries "git" "nvim"
 
-mkdir -p "$HOME/.config/nvim"
+mkdir -p "$HOME/.config/nvim/lua"
 cp -f "${DOT_ROOT}/files/nvim/init.lua" "$HOME/.config/nvim/init.lua"
+cp -Rf "${DOT_ROOT}/files/nvim/lua/." "$HOME/.config/nvim/lua/"
 
 echo "-> neovim setup finished."


### PR DESCRIPTION
## Summary
- Split `files/nvim/init.lua` into `lua/{options,ui,navigation,editor,treesitter,lsp,format}.lua` so each concern (and its keymaps) lives together; `init.lua` is now a thin bootstrap.
- Added `conform.nvim` + `yamlfmt` (format-on-save for YAML), auto-installed via `mason-tool-installer.nvim`.
- `nvim-tree`: show gitignored files/dotfiles by default, sync tree to focused file.
- Telescope: added gitignore-aware `fF`/`fG` variants alongside existing `ff`/`fg`.
- Enabled persistent `gitsigns` inline line blame.
- Disabled `nord.nvim`'s background so the terminal's transparency (ghostty `background-opacity`) shows through.
- `scripts/35_setup_nvim.sh` now copies the `lua/` directory alongside `init.lua`.
- Updated `README.md` and `files/help/neovim` to match.
- Unrelated: dropped ghostty `background-opacity` from 0.95 to 0.85 (separate commit).

## Test plan
- [x] Manually verified `shfmt`/`shellcheck`/`bash -n` pass on `scripts/35_setup_nvim.sh` (`make lint` itself is blocked in this environment by a pre-existing missing `python3-tomllib`, unrelated to this change)
- [x] Verified all new `lua/*.lua` modules `require()` cleanly with the correct runtimepath and produce the expected plugin spec counts
- [x] Deployed via `scripts/35_setup_nvim.sh` and confirmed `~/.config/nvim` has the correct flat layout (no nested `lua/lua`)
- [x] Manually exercised in nvim: transparency, gitignored file/grep search, nvim-tree path copy, persistent git blame, YAML format-on-save (until it correctly flagged a real syntax error in an external file)

🤖 Generated with [Claude Code](https://claude.com/claude-code)