### PR TITLE
Add network speed to tmux status bar

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -104,7 +104,7 @@ set -g status-justify centre
 set -g status-left-length 100
 set -g status-style "fg=${gray_light},bg=default"
 set -g status-left "#[fg=${green_soft},bold] #S "
-set -g status-right " ⚙ #{cpu_percentage} | ▤ #{ram_percentage} "
+set -g status-right " ⚙ #{cpu_percentage} | ▤ #{ram_percentage} | ↕ #{net_speed_dl}/#{net_speed_ul} "
 set -g window-status-current-format "#[fg=${cyan_soft},bold] ● #I:#W#{?window_zoomed_flag, 󰍋 ,}"
 set -g window-status-format " #I:#W"
 set -g window-status-activity-style "fg=${blue_muted},italics"
@@ -121,5 +121,6 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-cpu'
+set -g @plugin 'tmux-plugins/tmux-net-speed'
 
 run '~/.tmux/plugins/tpm/tpm || true'


### PR DESCRIPTION
Add network throughput info to the tmux status bar, next to CPU and memory.

## Changes

- Added `tmux-plugins/tmux-net-speed` plugin to the TPM plugin list (alongside `tmux-cpu`)
- Extended `status-right` with a network segment: `↕ #{net_speed_dl}/#{net_speed_ul}`, matching the existing icon + separator visual style

**Before:**
```
⚙ #{cpu_percentage} | ▤ #{ram_percentage}
```

**After:**
```
⚙ #{cpu_percentage} | ▤ #{ram_percentage} | ↕ #{net_speed_dl}/#{net_speed_ul}
```

The plugin is installed automatically by TPM on next `make install` (or `make reinstall` to force-fetch).

Closes #114

---
_Generated by [Claude Code](https://claude.ai/code/session_01EoiWi9So1Q2AxWzQqUkCAt)_