### PR TITLE
Revert tmux network speed status segment

### DIFF
--- a/files/tmux/tmux.conf
+++ b/files/tmux/tmux.conf
@@ -107,7 +107,7 @@ set -g status-justify centre
 set -g status-left-length 100
 set -g status-style "fg=${gray_light},bg=default"
 set -g status-left "#[fg=${green_soft},bold] #S "
-set -g status-right " ⚙ #{cpu_percentage} | ▤ #{ram_percentage} | ↕ #{net_speed_dl}/#{net_speed_ul} "
+set -g status-right " ⚙ #{cpu_percentage} | ▤ #{ram_percentage} "
 set -g window-status-current-format "#[fg=${cyan_soft},bold] ● #I:#W#{?window_zoomed_flag, 󰍋 ,}"
 set -g window-status-format " #I:#W"
 set -g window-status-activity-style "fg=${blue_muted},italics"
@@ -124,6 +124,5 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 set -g @plugin 'tmux-plugins/tmux-resurrect'
 set -g @plugin 'tmux-plugins/tmux-continuum'
 set -g @plugin 'tmux-plugins/tmux-cpu'
-set -g @plugin 'tmux-plugins/tmux-net-speed'
 
 run '~/.tmux/plugins/tpm/tpm || true'


### PR DESCRIPTION
## Summary
- PR #115 (closing #114) added a network speed segment to the tmux status bar using the `tmux-net-speed` plugin, but it referenced non-existent format variables (`#{net_speed_dl}`/`#{net_speed_ul}`) and the plugin only supports Linux (reads `/sys/class/net/`), so it silently showed nothing on macOS.
- A cross-platform replacement was prototyped but caused the centered status bar to jitter/shift window positions as the segment's width changed.
- Per user request, revert cleanly to the pre-#114 status bar: CPU/RAM only, no network segment.

## Test plan
- [x] `make lint` passes
- [x] Verified `status-right` matches the state before commit 336a5ed
- [x] Reloaded live tmux session and visually confirmed status bar shows only CPU/RAM