### PR TITLE
feat(nvim): add refactoring.nvim, harpoon, trouble.nvim, aerial.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ My dotfiles for macOS and Linux.
 - **starship** — shell prompt
 - **tmux** — terminal multiplexer
 - **vim** — editor
-- **neovim** — editor (lazy.nvim plugin manager, nord theme, telescope, neo-tree, flash.nvim, mason/LSP, conform formatting, nvim-dap debugging)
+- **neovim** — editor (lazy.nvim plugin manager, nord theme, telescope, neo-tree, flash.nvim, harpoon, trouble.nvim, aerial.nvim, mason/LSP, conform formatting, nvim-dap debugging, refactoring.nvim)
 - **git** — global config
 - **vscode** — editor settings
 - **ghostty** — terminal emulator config

--- a/files/help/neovim
+++ b/files/help/neovim
@@ -26,6 +26,16 @@ Inside Telescope: type to filter, `↑/↓` or `Ctrl+k/j` to move, `Enter` to op
 
 Note: live grep requires `ripgrep` (`brew install ripgrep`).
 
+## Fast file switching (harpoon)
+
+Working set of a handful of files for the current task, separate from Telescope/neo-tree.
+
+| Key         | Action                        |
+|-------------|--------------------------------|
+| `Space+a`   | Add current file to harpoon list |
+| `Ctrl+e`    | Toggle harpoon quick menu      |
+| `Space+1`-`4` | Jump to harpoon file 1-4     |
+
 ## File explorer (neo-tree)
 
 Hidden and git-ignored files are shown by default. Use `H` to toggle them.
@@ -69,6 +79,25 @@ Sources: filesystem, buffers, git status, document symbols (LSP). Click a tab in
 
 LSP servers: `pyright`/`ruff` (Python), `yamlls` (YAML), `marksman` (Markdown — go-to-definition/completion for links and references, diagnostics for broken links).
 
+## Diagnostics list (trouble.nvim)
+
+Project-wide list of errors/warnings, instead of hopping buffer-by-buffer with `[d`/`]d`.
+
+| Key          | Action                        |
+|--------------|-------------------------------|
+| `Space+xx`   | Toggle diagnostics (workspace) |
+| `Space+xX`   | Toggle diagnostics (current buffer) |
+
+## Refactoring (refactoring.nvim)
+
+Select the code in visual mode first, then invoke.
+
+| Key         | Action                        |
+|-------------|--------------------------------|
+| `Space+re`  | Extract function (visual mode) |
+| `Space+rv`  | Extract variable (visual mode) |
+| `Space+ri`  | Inline variable                |
+
 ## Markdown (markview.nvim)
 
 Headings, lists, tables, and code blocks render in-buffer automatically when opening a `.md` file — no separate preview window needed.
@@ -76,6 +105,14 @@ Headings, lists, tables, and code blocks render in-buffer automatically when ope
 | Key         | Action                        |
 |-------------|--------------------------------|
 | `Space+mv`  | Toggle markdown preview rendering |
+
+## Outline (aerial.nvim)
+
+Headings/symbols sidebar for jumping around long markdown docs (runbooks, READMEs) or source files.
+
+| Key        | Action                        |
+|------------|-------------------------------|
+| `Space+o`  | Toggle outline sidebar        |
 
 ## Git changes (gitsigns)
 

--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -1,6 +1,16 @@
 return {
     { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
     {
+        "ThePrimeagen/refactoring.nvim", -- extract function/variable, inline variable
+        dependencies = { "nvim-lua/plenary.nvim", "nvim-treesitter/nvim-treesitter" },
+        opts = {},
+        keys = {
+            { "<Leader>re", function() require("refactoring").refactor("Extract Function") end, mode = "v", desc = "Extract function" },
+            { "<Leader>rv", function() require("refactoring").refactor("Extract Variable") end, mode = "v", desc = "Extract variable" },
+            { "<Leader>ri", function() require("refactoring").refactor("Inline Variable") end, mode = { "n", "v" }, desc = "Inline variable" },
+        },
+    },
+    {
         "lewis6991/gitsigns.nvim", -- git diff indicators in the sign column, hunk navigation and staging
         opts = {
             current_line_blame = true,

--- a/files/nvim/lua/navigation.lua
+++ b/files/nvim/lua/navigation.lua
@@ -74,4 +74,37 @@ return {
         },
     },
     { "christoomey/vim-tmux-navigator" }, -- seamless navigation between neovim splits and tmux panes
+    {
+        "ThePrimeagen/harpoon", -- fast switching between a small working set of files (fewer than 5) for the current task
+        branch = "harpoon2",
+        dependencies = { "nvim-lua/plenary.nvim" },
+        config = function() require("harpoon"):setup() end,
+        keys = (function()
+            local keys = {
+                { "<Leader>a", function() require("harpoon"):list():add() end, desc = "Harpoon: add file" },
+                { "<C-e>", function() require("harpoon").ui:toggle_quick_menu(require("harpoon"):list()) end, desc = "Harpoon: toggle menu" },
+            }
+            for i = 1, 4 do
+                table.insert(keys, { "<Leader>" .. i, function() require("harpoon"):list():select(i) end, desc = "Harpoon: go to " .. i })
+            end
+            return keys
+        end)(),
+    },
+    {
+        "folke/trouble.nvim", -- project-wide diagnostics/quickfix/loclist list (Problems panel equivalent)
+        dependencies = { "nvim-tree/nvim-web-devicons" },
+        opts = {},
+        keys = {
+            { "<Leader>xx", "<cmd>Trouble diagnostics toggle<CR>", desc = "Diagnostics (workspace)" },
+            { "<Leader>xX", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Diagnostics (buffer)" },
+        },
+    },
+    {
+        "stevearc/aerial.nvim", -- headings/symbols outline sidebar; used for jumping around long markdown docs
+        dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
+        opts = {},
+        keys = {
+            { "<Leader>o", "<cmd>AerialToggle<CR>", desc = "Toggle outline (symbols/headings)" },
+        },
+    },
 }


### PR DESCRIPTION
## Summary
- Add `refactoring.nvim` (extract function/variable, inline variable) — closes the gap where only bare LSP rename existed
- Add `harpoon2` for a fast working-set of files, `trouble.nvim` as a project-wide diagnostics list, and `aerial.nvim` as a headings/symbols outline for navigating long markdown docs
- Update `README.md` and `files/help/neovim` to reflect the new plugins/keybindings

## Test plan
- [x] `make lint` passes (53/53)
- [x] `:Lazy sync` installs all four new plugins cleanly
- [x] Verified each new keymap registers with no load errors (`Space+re/rv/ri`, `Space+a`/`Ctrl+e`/`Space+1-4`, `Space+xx/xX`, `Space+o`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)