### PR TITLE
feat: wire up nvim-cmp completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ My dotfiles for macOS and Linux.
 - **starship** — shell prompt
 - **tmux** — terminal multiplexer
 - **vim** — editor
-- **neovim** — editor (lazy.nvim plugin manager, nord theme, telescope, neo-tree, flash.nvim, harpoon, trouble.nvim, aerial.nvim, mason/LSP, conform formatting, nvim-dap debugging, refactoring.nvim)
+- **neovim** — editor (lazy.nvim plugin manager, nord theme, telescope, neo-tree, flash.nvim, harpoon, trouble.nvim, aerial.nvim, mason/LSP, nvim-cmp completion, conform formatting, nvim-dap debugging, refactoring.nvim)
 - **git** — global config
 - **vscode** — editor settings
 - **ghostty** — terminal emulator config

--- a/files/help/neovim
+++ b/files/help/neovim
@@ -24,11 +24,7 @@ Leader key is `Space`.
 
 Inside Telescope: type to filter, `↑/↓` or `Ctrl+k/j` to move, `Enter` to open, `Ctrl+v` for vertical split, `Ctrl+x` for horizontal split.
 
-Note: live grep requires `ripgrep` (`brew install ripgrep`).
-
 ## Fast file switching (harpoon)
-
-Working set of a handful of files for the current task, separate from Telescope/neo-tree.
 
 | Key         | Action                        |
 |-------------|--------------------------------|
@@ -78,6 +74,18 @@ Sources: filesystem, buffers, git status, document symbols (LSP). Click a tab in
 | `]d`   | Next diagnostic               |
 
 LSP servers: `pyright`/`ruff` (Python), `yamlls` (YAML), `marksman` (Markdown — go-to-definition/completion for links and references, diagnostics for broken links).
+
+## Completion (nvim-cmp)
+
+Insert mode only, triggers automatically as you type. Sources: LSP, file paths, buffer words.
+
+| Key          | Action                        |
+|--------------|--------------------------------|
+| `Tab`        | Next item in menu (else normal Tab) |
+| `Shift+Tab`  | Previous item in menu (else normal Tab) |
+| `Enter`      | Confirm — only if an item was explicitly selected |
+| `Ctrl+Space` | Force-open completion menu    |
+| `Ctrl+e`     | Abort/close menu              |
 
 ## Diagnostics list (trouble.nvim)
 

--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -4,6 +4,10 @@ return {
 		"williamboman/mason-lspconfig.nvim", -- bridges mason and nvim-lspconfig; auto-installs and configures LSPs
 		dependencies = { "neovim/nvim-lspconfig" },
 		config = function()
+			-- Advertise nvim-cmp's completion capabilities to every server; per-server
+			-- vim.lsp.config calls below merge on top of this base.
+			vim.lsp.config("*", { capabilities = require("cmp_nvim_lsp").default_capabilities() })
+
 			-- Per-server overrides via the native vim.lsp.config API; mason-lspconfig's
 			-- automatic_enable picks these up when it calls vim.lsp.enable() for installed servers.
 			vim.lsp.config("yamlls", {
@@ -43,11 +47,45 @@ return {
 	},
 	{
 		"hrsh7th/nvim-cmp", -- autocompletion menu
+		event = "InsertEnter",
 		dependencies = {
 			"hrsh7th/cmp-nvim-lsp", -- LSP completions
 			"hrsh7th/cmp-buffer", -- buffer word completions
 			"hrsh7th/cmp-path", -- file path completions
 		},
+		config = function()
+			local cmp = require("cmp")
+			cmp.setup({
+				snippet = {
+					expand = function(args) vim.snippet.expand(args.body) end,
+				},
+				mapping = cmp.mapping.preset.insert({
+					["<Tab>"] = cmp.mapping(function(fallback)
+						if cmp.visible() then
+							cmp.select_next_item()
+						else
+							fallback()
+						end
+					end, { "i", "s" }),
+					["<S-Tab>"] = cmp.mapping(function(fallback)
+						if cmp.visible() then
+							cmp.select_prev_item()
+						else
+							fallback()
+						end
+					end, { "i", "s" }),
+					["<CR>"] = cmp.mapping.confirm({ select = false }),
+					["<C-Space>"] = cmp.mapping.complete(),
+					["<C-e>"] = cmp.mapping.abort(),
+				}),
+				sources = cmp.config.sources({
+					{ name = "nvim_lsp" },
+					{ name = "path" },
+				}, {
+					{ name = "buffer" },
+				}),
+			})
+		end,
 	},
 	{ "b0o/SchemaStore.nvim" }, -- provides 500+ JSON/YAML schemas (Kubernetes, Helm, GitHub Actions, etc.)
 }

--- a/files/nvim/lua/navigation.lua
+++ b/files/nvim/lua/navigation.lua
@@ -1,13 +1,20 @@
 local map = vim.keymap.set
 
--- neo-tree: sidebar and floating file explorer
+-- neo-tree
 map("n", "<Leader>e", "<cmd>Neotree toggle position=left<CR>", { desc = "Toggle file explorer (sidebar)" })
 map("n", "<Leader>E", "<cmd>Neotree toggle position=float<CR>", { desc = "Toggle file explorer (floating)" })
+
+-- telescope
 map("n", "<Leader>ff", "<cmd>Telescope find_files<CR>")
-map("n", "<Leader>fF", function() require("telescope.builtin").find_files({ no_ignore = true }) end)
+map("n", "<Leader>fF", function()
+	require("telescope.builtin").find_files({ no_ignore = true })
+end, { desc = "Telescope find_files, including gitignored" })
 map("n", "<Leader>fg", "<cmd>Telescope live_grep<CR>")
-map("n", "<Leader>fG", function() require("telescope.builtin").live_grep({ additional_args = { "--no-ignore" } }) end)
+map("n", "<Leader>fG", function()
+	require("telescope.builtin").live_grep({ additional_args = { "--no-ignore" } })
+end, { desc = "Telescope live_grep, including gitignored" })
 map("n", "<Leader>fb", "<cmd>Telescope buffers<CR>")
+
 -- vim-tmux-navigator: navigate splits/panes from any mode
 map({ "n", "i", "v" }, "<C-h>", "<cmd>TmuxNavigateLeft<CR>")
 map({ "n", "i", "v" }, "<C-j>", "<cmd>TmuxNavigateDown<CR>")
@@ -15,96 +22,116 @@ map({ "n", "i", "v" }, "<C-k>", "<cmd>TmuxNavigateUp<CR>")
 map({ "n", "i", "v" }, "<C-l>", "<cmd>TmuxNavigateRight<CR>")
 
 return {
-    {
-        "nvim-neo-tree/neo-tree.nvim", -- file explorer sidebar and floating panel
-        branch = "v3.x",
-        dependencies = {
-            "nvim-lua/plenary.nvim",
-            "nvim-tree/nvim-web-devicons",
-            "MunifTanjim/nui.nvim",
-        },
-        opts = {
-            popup_border_style = "rounded",
-            sources = { "filesystem", "buffers", "git_status", "document_symbols" },
-            document_symbols = {
-                follow_cursor = true,
-                window = {
-                    mappings = {
-                        ["<space>"] = { "toggle_node", nowait = true }, -- expand instantly, don't wait for a leader sequence
-                    },
-                },
-            },
-            source_selector = {
-                winbar = true,
-                sources = {
-                    { source = "filesystem",       display_name = " Files" },
-                    { source = "buffers",          display_name = " Buffers" },
-                    { source = "git_status",       display_name = " Git" },
-                    { source = "document_symbols", display_name = " Symbols" },
-                },
-            },
-            window = {
-                mappings = {
-                    ["<Tab>"] = "next_source",
-                    ["<S-Tab>"] = "prev_source",
-                },
-            },
-            filesystem = {
-                filtered_items = {
-                    visible = true,
-                    hide_dotfiles = false,
-                    hide_gitignored = false,
-                },
-                follow_current_file = { enabled = true },
-            },
-        },
-    },
-    {
-        "nvim-telescope/telescope.nvim", -- fuzzy finder for files, grep, buffers, git history
-        dependencies = { "nvim-lua/plenary.nvim" },
-        opts = {},
-    },
-    {
-        "folke/flash.nvim", -- enhanced f/F/t/T motions with labeled jump targets
-        opts = {
-            modes = {
-                char = { enabled = true, jump_labels = true },
-                search = { enabled = false },
-            },
-        },
-    },
-    { "christoomey/vim-tmux-navigator" }, -- seamless navigation between neovim splits and tmux panes
-    {
-        "ThePrimeagen/harpoon", -- fast switching between a small working set of files (fewer than 5) for the current task
-        branch = "harpoon2",
-        dependencies = { "nvim-lua/plenary.nvim" },
-        config = function() require("harpoon"):setup() end,
-        keys = (function()
-            local keys = {
-                { "<Leader>a", function() require("harpoon"):list():add() end, desc = "Harpoon: add file" },
-                { "<C-e>", function() require("harpoon").ui:toggle_quick_menu(require("harpoon"):list()) end, desc = "Harpoon: toggle menu" },
-            }
-            for i = 1, 4 do
-                table.insert(keys, { "<Leader>" .. i, function() require("harpoon"):list():select(i) end, desc = "Harpoon: go to " .. i })
-            end
-            return keys
-        end)(),
-    },
-    {
-        "folke/trouble.nvim", -- project-wide diagnostics/quickfix/loclist list (Problems panel equivalent)
-        dependencies = { "nvim-tree/nvim-web-devicons" },
-        opts = {},
-        keys = {
-            { "<Leader>xx", "<cmd>Trouble diagnostics toggle<CR>", desc = "Diagnostics (workspace)" },
-            { "<Leader>xX", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Diagnostics (buffer)" },
-        },
-    },
-    {
-        "stevearc/aerial.nvim", -- headings/symbols outline sidebar; used for jumping around long markdown docs
-        dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
-        opts = {},
-        keys = {
-            { "<Leader>o", "<cmd>AerialToggle<CR>", desc = "Toggle outline (symbols/headings)" },
-        },
-    },
+	{
+		"nvim-neo-tree/neo-tree.nvim", -- file explorer sidebar and floating panel
+		branch = "v3.x",
+		dependencies = {
+			"nvim-lua/plenary.nvim",
+			"nvim-tree/nvim-web-devicons",
+			"MunifTanjim/nui.nvim",
+		},
+		opts = {
+			popup_border_style = "rounded",
+			sources = { "filesystem", "buffers", "git_status", "document_symbols" },
+			document_symbols = {
+				follow_cursor = true,
+				window = {
+					mappings = {
+						["<space>"] = { "toggle_node", nowait = true }, -- expand instantly, don't wait for a leader sequence
+					},
+				},
+			},
+			source_selector = {
+				winbar = true,
+				sources = {
+					{ source = "filesystem", display_name = " Files" },
+					{ source = "buffers", display_name = " Buffers" },
+					{ source = "git_status", display_name = " Git" },
+					{ source = "document_symbols", display_name = " Symbols" },
+				},
+			},
+			window = {
+				mappings = {
+					["<Tab>"] = "next_source",
+					["<S-Tab>"] = "prev_source",
+				},
+			},
+			filesystem = {
+				filtered_items = {
+					visible = true,
+					hide_dotfiles = false,
+					hide_gitignored = false,
+				},
+				follow_current_file = { enabled = true },
+			},
+		},
+	},
+	{
+		"nvim-telescope/telescope.nvim", -- fuzzy finder for files, grep, buffers, git history
+		dependencies = { "nvim-lua/plenary.nvim" },
+		opts = {},
+	},
+	{
+		"folke/flash.nvim", -- enhanced f/F/t/T motions with labeled jump targets
+		opts = {
+			modes = {
+				char = { enabled = true, jump_labels = true },
+				search = { enabled = false },
+			},
+		},
+	},
+	{ "christoomey/vim-tmux-navigator" }, -- seamless navigation between neovim splits and tmux panes
+	{
+		"ThePrimeagen/harpoon", -- fast switching between a small working set of files (fewer than 5) for the current task
+		branch = "harpoon2",
+		dependencies = { "nvim-lua/plenary.nvim" },
+		config = function()
+			require("harpoon"):setup()
+		end,
+		keys = (function()
+			local keys = {
+				{
+					"<Leader>a",
+					function()
+						require("harpoon"):list():add()
+					end,
+					desc = "Harpoon: add file",
+				},
+				{
+					"<C-e>",
+					function()
+						require("harpoon").ui:toggle_quick_menu(require("harpoon"):list())
+					end,
+					desc = "Harpoon: toggle menu",
+				},
+			}
+			for i = 1, 4 do
+				table.insert(keys, {
+					"<Leader>" .. i,
+					function()
+						require("harpoon"):list():select(i)
+					end,
+					desc = "Harpoon: go to " .. i,
+				})
+			end
+			return keys
+		end)(),
+	},
+	{
+		"folke/trouble.nvim", -- project-wide diagnostics/quickfix/loclist list (Problems panel equivalent)
+		dependencies = { "nvim-tree/nvim-web-devicons" },
+		opts = {},
+		keys = {
+			{ "<Leader>xx", "<cmd>Trouble diagnostics toggle<CR>", desc = "Diagnostics (workspace)" },
+			{ "<Leader>xX", "<cmd>Trouble diagnostics toggle filter.buf=0<CR>", desc = "Diagnostics (buffer)" },
+		},
+	},
+	{
+		"stevearc/aerial.nvim", -- headings/symbols outline sidebar; used for jumping around long markdown docs
+		dependencies = { "nvim-treesitter/nvim-treesitter", "nvim-tree/nvim-web-devicons" },
+		opts = {},
+		keys = {
+			{ "<Leader>o", "<cmd>AerialToggle<CR>", desc = "Toggle outline (symbols/headings)" },
+		},
+	},
 }


### PR DESCRIPTION
nvim-cmp was installed as a dependency but never configured, so completion silently did nothing. Advertise LSP capabilities to every server via vim.lsp.config("*", ...) and add cmp.setup() with Tab/S-Tab cycling, explicit-select-to-confirm, and force-open/abort mappings.

Also carries forward local formatting/desc-field tweaks to navigation.lua and files/help/neovim made before this branch existed.