### PR TITLE
fix: resolve venv python for pyright LSP

### DIFF
--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -31,6 +31,16 @@ return {
 					function(server_name)
 						require("lspconfig")[server_name].setup({})
 					end,
+					["pyright"] = function()
+						require("lspconfig").pyright.setup({
+							before_init = function(_, config)
+								local venv_python = config.root_dir .. "/.venv/bin/python"
+								if vim.uv.fs_stat(venv_python) then
+									config.settings.python.pythonPath = venv_python
+								end
+							end,
+						})
+					end,
 					["yamlls"] = function()
 						require("lspconfig").yamlls.setup({
 							settings = {


### PR DESCRIPTION
## Summary
- Add a dedicated `pyright` handler in `files/nvim/lua/lsp.lua` that points pyright at `.venv/bin/python` when present, so it resolves deps installed via `uv sync` instead of falling back to `$PATH`'s python.

Fixes #119

## Test plan
- [x] `make lint`