### PR TITLE
Add per-window diagnostic navigation (]d / [d)

### DIFF
--- a/files/help/neovim
+++ b/files/help/neovim
@@ -70,8 +70,8 @@ Sources: filesystem, buffers, git status, document symbols (LSP). Click a tab in
 | `gd`   | Go to definition              |
 | `gr`   | Find references               |
 | `K`    | Hover documentation           |
-| `[d`   | Previous diagnostic           |
-| `]d`   | Next diagnostic               |
+| `[d`   | Previous diagnostic (current window) |
+| `]d`   | Next diagnostic (current window)     |
 
 LSP servers: `pyright`/`ruff` (Python), `yamlls` (YAML), `marksman` (Markdown — go-to-definition/completion for links and references, diagnostics for broken links).
 
@@ -89,7 +89,7 @@ Insert mode only, triggers automatically as you type. Sources: LSP, file paths, 
 
 ## Diagnostics list (trouble.nvim)
 
-Project-wide list of errors/warnings, instead of hopping buffer-by-buffer with `[d`/`]d`.
+Project-wide list of errors/warnings across all buffers; `[d`/`]d` navigate within the current window only.
 
 | Key          | Action                        |
 |--------------|-------------------------------|

--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -1,3 +1,11 @@
+local map = vim.keymap.set
+map("n", "]d", function()
+	vim.diagnostic.jump({ count = 1, float = true })
+end, { desc = "Next diagnostic" })
+map("n", "[d", function()
+	vim.diagnostic.jump({ count = -1, float = true })
+end, { desc = "Previous diagnostic" })
+
 return {
 	{ "williamboman/mason.nvim", opts = {} }, -- installs and manages language servers
 	{


### PR DESCRIPTION
## Summary

- Adds `]d` / `[d` keymaps in `files/nvim/lua/lsp.lua` using `vim.diagnostic.jump` (the nvim 0.11+ replacement for the deprecated `goto_next`/`goto_prev`).
- These operate on the current window directly, so they behave correctly in split layouts — unlike Trouble's globally-tracked "main" window which can clobber the wrong split.
- Updates `files/help/neovim` cheat sheet to clarify the per-window scope of `[d`/`]d` and distinguish them from Trouble's workspace-wide list.

Closes #120

---
_Generated by [Claude Code](https://claude.ai/code/session_016txMXYDwU16HybZ8oM6283)_