### PR TITLE
feat: add per-window diagnostic navigation

### DIFF
--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -1,3 +1,14 @@
+local map = vim.keymap.set
+
+-- Per-window diagnostic navigation; unlike Trouble's jump list, these always
+-- operate on the current window regardless of split layout.
+map("n", "]d", function()
+	vim.diagnostic.jump({ count = 1, float = true })
+end, { desc = "Next diagnostic" })
+map("n", "[d", function()
+	vim.diagnostic.jump({ count = -1, float = true })
+end, { desc = "Previous diagnostic" })
+
 return {
 	{ "williamboman/mason.nvim", opts = {} }, -- installs and manages language servers
 	{


### PR DESCRIPTION
## Summary
- Add native `]d`/`[d` mappings via `vim.diagnostic.jump` in `files/nvim/lua/lsp.lua`. These operate on the current window, unlike Trouble's jump list which reuses a single globally tracked "main" window and can clobber the wrong split.
- `files/help/neovim` already documented these mappings, so no doc changes were needed.

Fixes #120

## Test plan
- [x] `make lint`