### PR TITLE
feat: add Terraform support to nvim

### DIFF
--- a/files/help/neovim
+++ b/files/help/neovim
@@ -73,7 +73,7 @@ Sources: filesystem, buffers, git status, document symbols (LSP). Click a tab in
 | `[d`   | Previous diagnostic           |
 | `]d`   | Next diagnostic               |
 
-LSP servers: `pyright`/`ruff` (Python), `yamlls` (YAML), `marksman` (Markdown — go-to-definition/completion for links and references, diagnostics for broken links).
+LSP servers: `pyright`/`ruff` (Python), `yamlls` (YAML), `marksman` (Markdown — go-to-definition/completion for links and references, diagnostics for broken links), `terraformls` (Terraform).
 
 ## Completion (nvim-cmp)
 

--- a/files/nvim/lua/format.lua
+++ b/files/nvim/lua/format.lua
@@ -8,11 +8,13 @@ return {
         "stevearc/conform.nvim", -- formats buffers on save using per-filetype formatters
         opts = {
             formatters_by_ft = {
-                yaml = { "yamlfmt" },
-                python = { "ruff_fix", "ruff_format" },
-                sh = { "shfmt" },
                 json = { "prettier" },
                 markdown = { "prettier" },
+                python = { "ruff_fix", "ruff_format" },
+                sh = { "shfmt" },
+                terraform = { "terraform_fmt" },
+                ["terraform-vars"] = { "terraform_fmt" },
+                yaml = { "yamlfmt" },
             },
             format_on_save = { timeout_ms = 500, lsp_fallback = true },
         },

--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -37,7 +37,7 @@ return {
 				},
 			})
 			require("mason-lspconfig").setup({
-				ensure_installed = { "pyright", "ruff", "yamlls", "marksman" },
+				ensure_installed = { "marksman", "pyright", "ruff", "terraformls", "yamlls" },
 				handlers = {
 					function(server_name)
 						require("lspconfig")[server_name].setup({})

--- a/files/nvim/lua/treesitter.lua
+++ b/files/nvim/lua/treesitter.lua
@@ -2,6 +2,10 @@ return {
     {
         "nvim-treesitter/nvim-treesitter", -- smarter syntax highlighting based on parse trees
         build = ":TSUpdate",
-        opts = { highlight = { enable = true }, indent = { enable = true }, ensure_installed = { "python", "yaml", "markdown", "markdown_inline" } },
+        opts = {
+            highlight = { enable = true },
+            indent = { enable = true },
+            ensure_installed = { "hcl", "markdown", "markdown_inline", "python", "terraform", "yaml" },
+        },
     },
 }


### PR DESCRIPTION
## Summary
- Add `terraformls` to the mason-lspconfig `ensure_installed` list in `files/nvim/lua/lsp.lua`
- Add `terraform`/`hcl` treesitter parsers in `files/nvim/lua/treesitter.lua`
- Wire up `terraform_fmt` for `terraform`/`terraform-vars` filetypes in `files/nvim/lua/format.lua` (format-on-save)
- Document `terraformls` in the `files/help/neovim` cheat sheet

## Test plan
- [x] `make lint`