### PR TITLE
feat: auto-write nvim buffers to reduce need for :w

### DIFF
--- a/files/nvim/lua/options.lua
+++ b/files/nvim/lua/options.lua
@@ -1,5 +1,6 @@
 -- Editor settings (mirrors vimrc)
 local opt = vim.opt
+opt.autowriteall = true -- write buffers automatically on events like buffer switch, :make, window change
 opt.clipboard = "unnamedplus"
 opt.cursorline = true
 opt.expandtab = true


### PR DESCRIPTION
## Summary
- Enable `autowriteall` in nvim so buffers save automatically on events like buffer switch, `:make`, or window change, instead of the debounced `Pocco81/auto-save.nvim` plugin originally proposed.
- No new plugin dependency; conform.nvim's format-on-save still applies since autowrite goes through the normal `:write` path.

Closes #125

## Test plan
- [x] `make lint` — 53 passed, 0 failed
- [x] Manually verified in nvim (user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)