### PR TITLE
fix: replace autowriteall with auto-save.nvim

### DIFF
--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -1,6 +1,17 @@
 return {
     { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
     {
+        "Pocco81/auto-save.nvim", -- auto-saves on InsertLeave/TextChanged, removing the need for :w; save runs through :w so conform's format_on_save still applies
+        event = { "InsertLeave", "TextChanged" },
+        opts = {
+            condition = function(buf)
+                -- exclude harpoon's quick-menu buffer: it has no file backing, and an
+                -- auto-save mid-edit triggers harpoon's own write handler, closing the popup
+                return vim.fn.getbufvar(buf, "&modifiable") == 1 and vim.bo[buf].filetype ~= "harpoon"
+            end,
+        },
+    },
+    {
         "ThePrimeagen/refactoring.nvim", -- extract function/variable, inline variable
         dependencies = { "nvim-lua/plenary.nvim", "nvim-treesitter/nvim-treesitter" },
         opts = {},

--- a/files/nvim/lua/options.lua
+++ b/files/nvim/lua/options.lua
@@ -1,6 +1,5 @@
 -- Editor settings (mirrors vimrc)
 local opt = vim.opt
-opt.autowriteall = true -- write buffers automatically on events like buffer switch, :make, window change
 opt.clipboard = "unnamedplus"
 opt.cursorline = true
 opt.expandtab = true


### PR DESCRIPTION
## Summary
- `autowriteall` (added in #126) only fires on classic Ex-commands (`:buffer`, `:edit`, `:next`, etc.) and silently no-ops for API-driven buffer switches used by telescope, harpoon, and neo-tree — so it didn't actually cover the primary navigation workflow.
- Replaces it with `Pocco81/auto-save.nvim`, hooking `InsertLeave`/`TextChanged` instead, which isn't tied to how a buffer switch happened. Save still runs through `:w`, so conform.nvim's format-on-save still applies.
- Excludes harpoon's quick-menu buffer (`filetype == "harpoon"`) from autosave: it has no file backing, and an autosave mid-edit triggered harpoon's own write handler, closing the popup.

## Test plan
- [x] `make lint` — 53 passed, 0 failed
- [x] Manually verified in nvim: editing + switching via telescope now saves; harpoon popup no longer closes (user)

🤖 Generated with [Claude Code](https://claude.com/claude-code)