### PR TITLE
fix: migrate pyright lsp config off dead mason-lspconfig handlers

### DIFF
--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -36,33 +36,16 @@ return {
 					},
 				},
 			})
+			vim.lsp.config("pyright", {
+				before_init = function(_, config)
+					local venv_python = config.root_dir .. "/.venv/bin/python"
+					if vim.uv.fs_stat(venv_python) then
+						config.settings.python.pythonPath = venv_python
+					end
+				end,
+			})
 			require("mason-lspconfig").setup({
 				ensure_installed = { "marksman", "pyright", "ruff", "terraformls", "yamlls" },
-				handlers = {
-					function(server_name)
-						require("lspconfig")[server_name].setup({})
-					end,
-					["pyright"] = function()
-						require("lspconfig").pyright.setup({
-							before_init = function(_, config)
-								local venv_python = config.root_dir .. "/.venv/bin/python"
-								if vim.uv.fs_stat(venv_python) then
-									config.settings.python.pythonPath = venv_python
-								end
-							end,
-						})
-					end,
-					["yamlls"] = function()
-						require("lspconfig").yamlls.setup({
-							settings = {
-								yaml = {
-									schemaStore = { enable = false, url = "" },
-									schemas = require("schemastore").yaml.schemas(),
-								},
-							},
-						})
-					end,
-				},
 			})
 		end,
 	},


### PR DESCRIPTION
## Summary
- mason-lspconfig v2 dropped the `handlers` table, so pyright's `before_init` (which sets `python.pythonPath` to the project's `.venv/bin/python`) silently never ran
- Moves pyright config to a top-level `vim.lsp.config()` call, matching the pattern already used for `yamlls` and `ruff`
- Removes the now fully-inert `handlers` block from `mason-lspconfig.setup()`

Closes #127

## Test plan
- [x] `make lint` passes
- [x] Verified manually in nvim: pyright now resolves `.venv/bin/python` in a real project