### PR TITLE
fix: stop auto-save from firing on undo, breaking undo

### DIFF
--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -1,9 +1,13 @@
 return {
     { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
     {
-        "Pocco81/auto-save.nvim", -- auto-saves on InsertLeave/TextChanged, removing the need for :w; save runs through :w so conform's format_on_save still applies
-        event = { "InsertLeave", "TextChanged" },
+        "Pocco81/auto-save.nvim", -- auto-saves on InsertLeave, removing the need for :w; save runs through :w so conform's format_on_save still applies
+        event = "InsertLeave",
         opts = {
+            -- TextChanged also fires on undo/redo; combined with conform's non-undojoined
+            -- format_on_save, that turns every `u` into a save+reformat that fights the undo
+            -- itself, making undo look broken. InsertLeave alone avoids the loop.
+            trigger_events = { "InsertLeave" },
             condition = function(buf)
                 -- exclude harpoon's quick-menu buffer: it has no file backing, and an
                 -- auto-save mid-edit triggers harpoon's own write handler, closing the popup


### PR DESCRIPTION
## Summary
- `auto-save.nvim`'s default `trigger_events` includes `TextChanged`, which per `:help TextChanged` fires on any Normal-mode text change — including undo/redo
- Combined with `conform.nvim`'s `format_on_save` (which doesn't use `undojoin`), every `u` triggered a save+reformat that pushed a new undo step on top of the change just undone, so undo never actually reached the state before the original mistake
- Restrict auto-save to `InsertLeave` only; pure Normal-mode-only edits (`dd`, `p`, `x` without ever entering insert mode) won't auto-save until the next `InsertLeave`, but the undo-fighting loop is gone

## Test plan
- [x] `make lint` passes
- [x] Verified manually in nvim: mistype → leave insert → `u` now cleanly undoes back through the mistake without the formatter re-fighting it