### PR TITLE
feat: enable pyright autoimport completions for python

### DIFF
--- a/files/nvim/lua/lsp.lua
+++ b/files/nvim/lua/lsp.lua
@@ -37,6 +37,13 @@ return {
 				},
 			})
 			vim.lsp.config("pyright", {
+				-- Offer unimported symbols in completion; nvim-cmp applies the resulting
+				-- additionalTextEdits (the import statement) automatically on confirm.
+				settings = {
+					python = {
+						analysis = { autoImportCompletions = true },
+					},
+				},
 				before_init = function(_, config)
 					local venv_python = config.root_dir .. "/.venv/bin/python"
 					if vim.uv.fs_stat(venv_python) then


### PR DESCRIPTION
## Summary
- Enables pyright's `python.analysis.autoImportCompletions` so unimported symbols show up in completion
- `nvim-cmp`'s LSP source already applies the resulting `additionalTextEdits` (the import line) automatically on confirm — no cmp config change needed
- Now that pyright's `pythonPath` resolves the project venv correctly (#127), this covers third-party packages too, not just stdlib

## Test plan
- [x] `make lint` passes
- [x] Verified manually in nvim: typing an unimported symbol and accepting the completion inserts the import statement automatically