### PR TITLE
fix: unset GOROOT before recomputing to avoid stale inheritance

### DIFF
--- a/files/zsh/zshrc
+++ b/files/zsh/zshrc
@@ -58,6 +58,7 @@ fi
 
 # golang
 if command -v go &> /dev/null; then
+  unset GOROOT
   export GOROOT="$(go env GOROOT)"
   export GOPATH="$HOME/go"
   export PATH="$PATH:$GOROOT/bin:$GOPATH/bin"


### PR DESCRIPTION
## Summary
- A long-lived tmux server can carry a `GOROOT` captured before a Homebrew Go upgrade in its global environment.
- Since `go env GOROOT` echoes back an already-set env var instead of recomputing it, the stale value would perpetuate into every new pane indefinitely.
- Fix: `unset GOROOT` before recomputing it in `zshrc`.

## Test plan
- [x] `make lint` (53/53 passed)
- [x] Verified locally: cleared stale `GOROOT` from a running tmux server's global env and confirmed a new pane resolves the correct `GOROOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)