### PR TITLE
fix: switch auto-save trigger from InsertLeave to FocusLost/BufLeave

### DIFF
--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -1,13 +1,10 @@
 return {
     { "kylechui/nvim-surround", event = "VeryLazy", opts = {} }, -- add/change/delete surrounding pairs (brackets, quotes, tags)
     {
-        "Pocco81/auto-save.nvim", -- auto-saves on InsertLeave, removing the need for :w; save runs through :w so conform's format_on_save still applies
-        event = "InsertLeave",
+        "Pocco81/auto-save.nvim", -- auto-saves on focus/buffer switch, removing the need for :w; save runs through :w so conform's format_on_save still applies
+        event = "VeryLazy",
         opts = {
-            -- TextChanged also fires on undo/redo; combined with conform's non-undojoined
-            -- format_on_save, that turns every `u` into a save+reformat that fights the undo
-            -- itself, making undo look broken. InsertLeave alone avoids the loop.
-            trigger_events = { "InsertLeave" },
+            trigger_events = { "FocusLost", "BufLeave" },
             condition = function(buf)
                 -- exclude harpoon's quick-menu buffer: it has no file backing, and an
                 -- auto-save mid-edit triggers harpoon's own write handler, closing the popup


### PR DESCRIPTION
## Summary
- InsertLeave fired on every edit, so conform's format_on_save ran mid-edit, fighting undo and stripping "unused" imports before the edit was finished.
- Switched trigger_events to FocusLost/BufLeave, which only fire when actually stepping away from the buffer.

## Test plan
- [ ] Edit a file with imports, leave insert mode mid-edit, confirm imports aren't stripped
- [ ] Confirm undo (`u`) works normally without fighting a reformat
- [ ] Confirm file still saves automatically on focus loss / buffer switch