### PR TITLE
fix: update refactoring.nvim dependency and API for its rewrite

### DIFF
--- a/files/nvim/lua/editor.lua
+++ b/files/nvim/lua/editor.lua
@@ -14,12 +14,11 @@ return {
     },
     {
         "ThePrimeagen/refactoring.nvim", -- extract function/variable, inline variable
-        dependencies = { "nvim-lua/plenary.nvim", "nvim-treesitter/nvim-treesitter" },
-        opts = {},
+        dependencies = { "lewis6991/async.nvim", "nvim-treesitter/nvim-treesitter" },
         keys = {
-            { "<Leader>re", function() require("refactoring").refactor("Extract Function") end, mode = "v", desc = "Extract function" },
-            { "<Leader>rv", function() require("refactoring").refactor("Extract Variable") end, mode = "v", desc = "Extract variable" },
-            { "<Leader>ri", function() require("refactoring").refactor("Inline Variable") end, mode = { "n", "v" }, desc = "Inline variable" },
+            { "<Leader>re", function() return require("refactoring").extract_func() end, mode = { "n", "x" }, desc = "Extract function", expr = true },
+            { "<Leader>rv", function() return require("refactoring").extract_var() end, mode = { "n", "x" }, desc = "Extract variable", expr = true },
+            { "<Leader>ri", function() return require("refactoring").inline_var() end, mode = { "n", "x" }, desc = "Inline variable", expr = true },
         },
     },
     {


### PR DESCRIPTION
## Summary
- refactoring.nvim's upstream rewrite (649a53c) dropped `plenary.async` in favor of `lewis6991/async.nvim` and replaced the old `refactor("Extract Function")` command API with expr-mapping functions (`extract_func`/`extract_var`/`inline_var`)
- Config still referenced the old dependency and API, breaking `<Leader>re`/`rv`/`ri` with "loop or previous error loading module 'refactoring'"

## Test plan
- [x] `require("refactoring")` loads cleanly after adding `lewis6991/async.nvim` and syncing lazy.nvim
- [x] `<Leader>re` in visual mode over a Python block correctly reaches the extract-function flow (prompts for a function name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)